### PR TITLE
feat: fetch risk framework directly in yDaemon

### DIFF
--- a/internal/daemons/risk.api.strategies.go
+++ b/internal/daemons/risk.api.strategies.go
@@ -3,9 +3,12 @@ package daemons
 import (
 	"encoding/json"
 	"io/ioutil"
+	"math/big"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/majorfi/ydaemon/internal/logs"
@@ -18,8 +21,7 @@ import (
 // and store the result to the global variable StrategiesFromRisk for later use.
 func FetchStrategiesFromRisk(chainID uint64) {
 	// Get the information from the Risk Framework
-	chainIDStr := strconv.FormatUint(chainID, 10)
-	resp, err := http.Get(utils.RISK_BASE_URL + chainIDStr)
+	resp, err := http.Get(utils.RISK_BASE_URL)
 	if err != nil {
 		logs.Error("Error fetching information from the Risk Framework", err)
 		return
@@ -35,21 +37,119 @@ func FetchStrategiesFromRisk(chainID uint64) {
 		return
 	}
 
-	// Unmarshal the response body into the variable StrategiesFromRisk. Body is a byte array,
-	// with this manipulation we are putting it in the correct TStrategyFromRisk struct format
-	strategies := make(map[common.Address]models.TStrategyFromRisk)
-	if err := json.Unmarshal(body, &strategies); err != nil {
+	// Unmarshal the response body into the variable StrategyGroupsFromRisk. Body is a byte array,
+	groups := []models.TStrategyGroupFromRisk{}
+	if err := json.Unmarshal(body, &groups); err != nil {
 		logs.Error("Error unmarshalling response body from the Risk Framework", err)
 		return
 	}
 
-	// To provide faster access to the data, we index the mapping by the vault address, aka
-	// {[vaultAddress]: TStrategyFromRisk} if we were working with JS/TS
+	// For each strategy in the meta, parse the strategy group scores
 	if store.StrategiesFromRisk[chainID] == nil {
 		store.StrategiesFromRisk[chainID] = make(map[common.Address]models.TStrategyFromRisk)
 	}
-	for address, strategy := range strategies {
-		store.StrategiesFromRisk[chainID][address] = strategy
+	strategies, ok := store.StrategiesFromMeta[chainID]
+	if !ok {
+		logs.Error("Error fetching strategies from meta")
+		return
+	}
+	for _, strat := range strategies {
+		var stratGroup models.TStrategyGroupFromRisk
+
+	groupLoop:
+		for _, group := range groups {
+			// Exclude strategies
+			if len(group.Criteria.Exclude) > 0 {
+				for _, stratExclude := range group.Criteria.Exclude {
+					if strings.Contains(strings.ToLower(strat.Name), strings.ToLower(stratExclude)) {
+						continue groupLoop
+					}
+				}
+			}
+			// Include strategies
+			if len(group.Criteria.Strategies) > 0 {
+				for _, stratInclude := range group.Criteria.Strategies {
+					if utils.ContainsAddress(strat.Addresses, stratInclude) {
+						stratGroup = group
+						break groupLoop
+					}
+				}
+			}
+
+			// Include nameLikes
+			if len(group.Criteria.NameLike) > 0 {
+				for _, nameLike := range group.Criteria.NameLike {
+					if strings.Contains(strings.ToLower(strat.Name), strings.ToLower(nameLike)) {
+						stratGroup = group
+						break groupLoop
+					}
+				}
+			}
+		}
+		// Skip if no group was found
+		if stratGroup.GroupID == "" {
+			break
+		}
+
+		// Loop over addresses
+		for _, address := range strat.Addresses {
+			addressHex := common.HexToAddress(address)
+
+			// Fetch activation and tvl from multicall
+			data, ok := store.StrategyMultiCallData[chainID][addressHex]
+			if !ok {
+				logs.Error("Error fetching strategy data from multicall")
+				return
+			}
+
+			// TVL Impact
+			var TVLImpact float64 = 5
+			if data.EstimatedTotalAssets.Cmp(big.NewInt(0)) == 0 {
+				TVLImpact = 0
+			} else if data.EstimatedTotalAssets.Cmp(big.NewInt(1_000_000)) < 0 {
+				TVLImpact = 1
+			} else if data.EstimatedTotalAssets.Cmp(big.NewInt(10_000_000)) < 0 {
+				TVLImpact = 2
+			} else if data.EstimatedTotalAssets.Cmp(big.NewInt(50_000_000)) < 0 {
+				TVLImpact = 3
+			} else if data.EstimatedTotalAssets.Cmp(big.NewInt(100_000_000)) < 0 {
+				TVLImpact = 4
+			}
+
+			// Longevity Impact
+			var LongevityImpact float64 = 5
+			if data.Activation != nil {
+				var longevity big.Int
+				now := big.NewInt(time.Now().Unix())
+				longevity.Sub(now, data.Activation)
+
+				var days int64 = 60 * 60 * 24
+				if longevity.Cmp(big.NewInt(240*days)) > 0 {
+					LongevityImpact = 1
+				} else if longevity.Cmp(big.NewInt(120*days)) > 0 {
+					LongevityImpact = 2
+				} else if longevity.Cmp(big.NewInt(30*days)) > 0 {
+					LongevityImpact = 3
+				} else if longevity.Cmp(big.NewInt(7*days)) > 0 {
+					LongevityImpact = 4
+				}
+			}
+
+			// Store strategy to DB
+			strategy := models.TStrategyFromRisk{
+				RiskScores: models.TStrategyFromRiskRiskScores{
+					TVLImpact:           TVLImpact,
+					AuditScore:          stratGroup.AuditScore,
+					CodeReviewScore:     stratGroup.CodeReviewScore,
+					ComplexityScore:     stratGroup.ComplexityScore,
+					LongevityImpact:     LongevityImpact,
+					ProtocolSafetyScore: stratGroup.ProtocolSafetyScore,
+					TeamKnowledgeScore:  stratGroup.TeamKnowledgeScore,
+					TestingScore:        stratGroup.TestingScore,
+				},
+			}
+			store.StrategiesFromRisk[chainID][addressHex] = strategy
+		}
 	}
 	store.SaveInDBForChainID(`StrategiesFromRisk`, chainID, store.StrategiesFromRisk[chainID])
 }

--- a/internal/models/risk.go
+++ b/internal/models/risk.go
@@ -1,0 +1,42 @@
+package models
+
+type TStrategyFromRiskRiskScores struct {
+	TVLImpact           float64 `json:"TVLImpact"`
+	AuditScore          float64 `json:"auditScore"`
+	CodeReviewScore     float64 `json:"codeReviewScore"`
+	ComplexityScore     float64 `json:"complexityScore"`
+	LongevityImpact     float64 `json:"longevityImpact"`
+	ProtocolSafetyScore float64 `json:"protocolSafetyScore"`
+	TeamKnowledgeScore  float64 `json:"teamKnowledgeScore"`
+	TestingScore        float64 `json:"testingScore"`
+}
+
+type TStrategyFromRiskRiskProfile struct {
+	High   float64 `json:"high"`
+	Low    float64 `json:"low"`
+	Median float64 `json:"median"`
+}
+
+type TStrategyFromRisk struct {
+	RiskScores TStrategyFromRiskRiskScores `json:"riskScores"`
+	// RiskProfile TStrategyFromRiskRiskProfile `json:"riskProfile"`
+	// Tokens      []string                     `json:"tokens"`
+}
+
+type TStrategyGroupCritieria struct {
+	NameLike   []string `json:"nameLike"`
+	Strategies []string `json:"strategies"`
+	Exclude    []string `json:"exclude"`
+}
+
+type TStrategyGroupFromRisk struct {
+	GroupID             string                  `json:"id"`
+	ChainID             uint64                  `json:"network"`
+	AuditScore          float64                 `json:"auditScore"`
+	CodeReviewScore     float64                 `json:"codeReviewScore"`
+	ComplexityScore     float64                 `json:"complexityScore"`
+	ProtocolSafetyScore float64                 `json:"protocolSafetyScore"`
+	TeamKnowledgeScore  float64                 `json:"teamKnowledgeScore"`
+	TestingScore        float64                 `json:"testingScore"`
+	Criteria            TStrategyGroupCritieria `json:"criteria"`
+}

--- a/internal/models/store.go
+++ b/internal/models/store.go
@@ -31,24 +31,3 @@ type TStrategyMultiCallData struct {
 	KeepCRV              *big.Int `json:"keepCRV"`
 	IsActive             bool     `json:"isActive"`
 }
-
-type TStrategyFromRiskRiskScores struct {
-	TVLImpact           float64 `json:"TVLImpact"`
-	AuditScore          float64 `json:"auditScore"`
-	CodeReviewScore     float64 `json:"codeReviewScore"`
-	ComplexityScore     float64 `json:"complexityScore"`
-	LongevityImpact     float64 `json:"longevityImpact"`
-	ProtocolSafetyScore float64 `json:"protocolSafetyScore"`
-	TeamKnowledgeScore  float64 `json:"teamKnowledgeScore"`
-	TestingScore        float64 `json:"testingScore"`
-}
-type TStrategyFromRiskRiskProfile struct {
-	High   float64 `json:"high"`
-	Low    float64 `json:"low"`
-	Median float64 `json:"median"`
-}
-type TStrategyFromRisk struct {
-	RiskScores  TStrategyFromRiskRiskScores  `json:"riskScores"`
-	RiskProfile TStrategyFromRiskRiskProfile `json:"riskProfile"`
-	Tokens      []string                     `json:"tokens"`
-}

--- a/internal/utils/constants.go
+++ b/internal/utils/constants.go
@@ -24,7 +24,7 @@ var META_BASE_PATH, _ = filepath.Abs(getCurrentPath() + `../../../data/meta`)
 var API_V1_BASE_URL = `https://api.yearn.finance/v1/chains/`
 
 // RISK_BASE_URL is the base URL to access the risk framework
-var RISK_BASE_URL = `https://d3971bp2359cnv.cloudfront.net/api/strategies/`
+var RISK_BASE_URL = `https://raw.githubusercontent.com/yearn/yearn-data-analytics/master/src/risk_framework/risks.json`
 
 // BLACKLISTED_VAULTS contains the vault we should not work with
 var BLACKLISTED_VAULTS = map[uint64][]common.Address{

--- a/internal/utils/helpers.go
+++ b/internal/utils/helpers.go
@@ -9,8 +9,8 @@ import (
 	"github.com/majorfi/ydaemon/internal/logs"
 )
 
-//ContainsAddress returns true if address exists in addresses
-func ContainsAddress(addresses []common.Address, address common.Address) bool {
+// ContainsAddress returns true if address exists in addresses
+func ContainsAddress[T comparable](addresses []T, address T) bool {
 	for _, _address := range addresses {
 		if _address == address {
 			return true


### PR DESCRIPTION
The Merrrrrrrge
mirrored in the PR from the data repo https://github.com/yearn/yearn-data-analytics/pull/71

* fetch the list of strategies from `store.StrategiesFromMeta`
* calculate the TVLImpact and LongevityImpact directly inside the `FetchStrategiesFromRisk` function
* tried to extend the `ContainsAddress` to a more generic comparable, to use it for string addresses as well