### PR TITLE
fix: curve ib-usdc apy to new

### DIFF
--- a/data/meta/vaults/1/0x1025b1641d1F23C289412Dd5E5701e9810103a93.json
+++ b/data/meta/vaults/1/0x1025b1641d1F23C289412Dd5E5701e9810103a93.json
@@ -9,5 +9,6 @@
   "allowZapIn": true,
   "allowZapOut": true,
   "retired": false,
+  "apyTypeOverride": "new",
   "displayName": "Curve ibAUD-USDC"
 }

--- a/data/meta/vaults/1/0x6B5ce31AF687a671a804d8070Ddda99Cab926dfE.json
+++ b/data/meta/vaults/1/0x6B5ce31AF687a671a804d8070Ddda99Cab926dfE.json
@@ -9,5 +9,6 @@
   "allowZapIn": true,
   "allowZapOut": true,
   "retired": false,
+  "apyTypeOverride": "new",
   "displayName": "Curve ibGBP-USDC"
 }

--- a/data/meta/vaults/1/0x9A39f31DD5EDF5919A5C0c2433cE053fAD2E0336.json
+++ b/data/meta/vaults/1/0x9A39f31DD5EDF5919A5C0c2433cE053fAD2E0336.json
@@ -9,5 +9,6 @@
   "allowZapIn": true,
   "allowZapOut": true,
   "retired": false,
+  "apyTypeOverride": "new",
   "displayName": "Curve ibJPY-USDC"
 }

--- a/data/meta/vaults/1/0xE5eDcE53e39Cbc6d819E2C340BCF295e0084ff7c.json
+++ b/data/meta/vaults/1/0xE5eDcE53e39Cbc6d819E2C340BCF295e0084ff7c.json
@@ -9,5 +9,6 @@
   "allowZapIn": true,
   "allowZapOut": true,
   "retired": false,
+  "apyTypeOverride": "new",
   "displayName": "Curve ibEUR-USDC"
 }

--- a/data/meta/vaults/1/0xF6B9DFE6bc42ed2eaB44D6B829017f7B78B29f88.json
+++ b/data/meta/vaults/1/0xF6B9DFE6bc42ed2eaB44D6B829017f7B78B29f88.json
@@ -9,5 +9,6 @@
   "allowZapIn": true,
   "allowZapOut": true,
   "retired": false,
+  "apyTypeOverride": "new",
   "displayName": "Curve ibKRW-USDC"
 }


### PR DESCRIPTION
This will set all curve ib-usdc vaults to new apy due to a pricing issue with the curve deposit token from lens. Not inculding Curve EURS-USDC since it seems to have accurate apy info atm. 