### PR TITLE
Experimenting isActive

### DIFF
--- a/internal/models/vault.go
+++ b/internal/models/vault.go
@@ -104,13 +104,20 @@ type TStrategyRisk struct {
 
 // TStrategy contains all the information useful about the strategies currently active in this vault.
 type TStrategy struct {
-	Address         string            `json:"address"`
-	Name            string            `json:"name"`
-	Description     string            `json:"description"`
-	DelegatedAssets string            `json:"-"`
-	DelegatedValue  string            `json:"-"`
-	Details         *TStrategyDetails `json:"details,omitempty"`
-	Risk            *TStrategyRisk    `json:"risk,omitempty"`
+	Address     string `json:"address"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+
+	//The following fields are used for internal computation
+	DelegatedAssets string `json:"-"`
+	DelegatedValue  string `json:"-"`
+	TotalDebt       string `json:"-"`
+	InQueue         bool   `json:"-"`
+	IsActive        bool   `json:"-"`
+	//End of internal computation fields
+
+	Details *TStrategyDetails `json:"details,omitempty"`
+	Risk    *TStrategyRisk    `json:"risk,omitempty"`
 }
 
 // TMigration helps us to know if a vault is in the process of being migrated.

--- a/internal/utils/constants.go
+++ b/internal/utils/constants.go
@@ -45,6 +45,7 @@ var BLACKLISTED_VAULTS = map[uint64][]common.Address{
 
 // STRATEGIES_CONDITIONS contains the possible conditions to determine which strategies should
 // be used in the return value.
+// If the strategy is `absolute`, an active strategy will be isActive, inQueue and with a debt > 0
 // If the strategy is `inQueue`, we will check if the vault has the strategy in it's withdrawal queue
 // If the strategy is `debtLimit`, we will check if the vault has allocated a debtLimit to the strategy
-var STRATEGIES_CONDITIONS = []string{`inQueue`, `debtLimit`}
+var STRATEGIES_CONDITIONS = []string{`inQueue`, `debtLimit`, `absolute`}


### PR DESCRIPTION
- Add `absolute` to the `STRATEGIES_CONDITIONS`. Absolute will only serve strategies that are `isActive`, `inQueue` and with a `totalDebt > 0`
- Add some internal-fields-only (with `json:"-"`) to bypass details struct limitation