### PR TITLE
fix: disable zaps for Balancer Boosted AAVE USD vault

### DIFF
--- a/data/meta/vaults/1/0x4213458C69c19E6792510E1153cb0c5834665fdC.json
+++ b/data/meta/vaults/1/0x4213458C69c19E6792510E1153cb0c5834665fdC.json
@@ -6,8 +6,8 @@
   "withdrawalsDisabled": false,
   "order": 18.4,
   "migrationAvailable": false,
-  "allowZapIn": true,
-  "allowZapOut": true,
+  "allowZapIn": false,
+  "allowZapOut": false,
   "retired": false,
   "apyTypeOverride": "new",
   "displayName": "Balancer Boosted AAVE USD"


### PR DESCRIPTION
- Temporarily disable zaps for Balancer Boosted AAVE USD vault until its supported by our zap provider Portals.fi

Currently FE fails:
![image](https://user-images.githubusercontent.com/18649057/189398045-62e0ed94-ddb7-4472-a681-4189fc9a27ec.png)
