### PR TITLE
Remove invalid property from tokenlist.json

### DIFF
--- a/data/meta/tokens/tokenList.json
+++ b/data/meta/tokens/tokenList.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "tokenList",
   "name": "Yearn",
   "timestamp": "2022-05-12T18:15:59+00:00",
   "version": {


### PR DESCRIPTION
The `$schema` is causing validation errors because it is not specified in the `tokenlist` JSON schema.

This property [was removed through a middleware](https://github.com/yearn/yearn-meta/blob/655393edd4f15fb1e917eaee12d0222f71ff2ed1/api/pages/api/tokens/list.tsx#L16) from the served JSON in the now archived https://github.com/yearn/yearn-meta but is now available again because the token list is served as a static file.