### PR TITLE
Beta - V0.2.0 - Registry fetcher

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/yearn/ydaemon/common/env"
 	"github.com/yearn/ydaemon/common/logs"
 	"github.com/yearn/ydaemon/common/store"
+	"github.com/yearn/ydaemon/internal"
 )
 
 var chains = env.SUPPORTED_CHAIN_IDS
@@ -55,7 +56,7 @@ func main() {
 	summonDaemonsForAllChains()
 	logs.Success(`Server ready!`)
 
-	// internal.Initialize(1) //For later
+	internal.Initialize(1)
 
 	NewRouter().Run()
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -139,7 +139,7 @@ func NewRouter() *gin.Engine {
 
 	{
 		//TEST
-		// router.GET(`core/harvests/:chainID/:address`, utils.GetHarvests)
+		router.GET(`core/harvests/:chainID/:address`, utils.GetHarvests)
 	}
 
 	return router

--- a/external/utils/route.helpers.go
+++ b/external/utils/route.helpers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/machinebox/graphql"
 	"github.com/yearn/ydaemon/common/env"
 	"github.com/yearn/ydaemon/common/helpers"
+	"github.com/yearn/ydaemon/internal"
 )
 
 //GetSupportedChains returns a list of supported chains by the API
@@ -17,35 +18,34 @@ func GetSupportedChains(c *gin.Context) {
 }
 
 //GetHarvests returns a list of harvests
-//For later
-// func GetHarvests(c *gin.Context) {
-// 	chainID, ok := helpers.AssertChainID(c.Param("chainID"))
-// 	if !ok {
-// 		c.String(http.StatusBadRequest, "invalid chainID")
-// 		return
-// 	}
-// 	address, ok := helpers.AssertAddress(c.Param("address"), chainID)
-// 	if !ok {
-// 		c.String(http.StatusBadRequest, "invalid address")
-// 		return
-// 	}
+func GetHarvests(c *gin.Context) {
+	chainID, ok := helpers.AssertChainID(c.Param("chainID"))
+	if !ok {
+		c.String(http.StatusBadRequest, "invalid chainID")
+		return
+	}
+	address, ok := helpers.AssertAddress(c.Param("address"), chainID)
+	if !ok {
+		c.String(http.StatusBadRequest, "invalid address")
+		return
+	}
 
-// 	allHarvest := internal.AllHarvests[address.Address]
+	allHarvest := internal.AllHarvests[address.Address]
 
-// 	sumOfAllGains := bigNumber.NewFloat(0)
-// 	sumOfAllFees := bigNumber.NewFloat(0)
-// 	for _, v := range allHarvest {
-// 		sumOfAllGains = sumOfAllGains.Add(sumOfAllGains, bigNumber.NewFloat().SetInt(v.Gain))
-// 		sumOfAllFees = sumOfAllFees.Add(sumOfAllFees, bigNumber.NewFloat().SetInt(v.Fees.TotalCollectedFee))
-// 		logs.Info(`Harvest fee ratio: `, bigNumber.NewFloat().Mul(v.Fees.TotalFeeRatio, bigNumber.NewFloat(100)).String()+`%`)
-// 	}
+	// sumOfAllGains := bigNumber.NewFloat(0)
+	// sumOfAllFees := bigNumber.NewFloat(0)
+	// for _, v := range allHarvest {
+	// 	sumOfAllGains = sumOfAllGains.Add(sumOfAllGains, bigNumber.NewFloat().SetInt(v.Gain))
+	// 	sumOfAllFees = sumOfAllFees.Add(sumOfAllFees, bigNumber.NewFloat().SetInt(v.Fees.TotalCollectedFee))
+	// 	logs.Info(`Harvest fee ratio: `, bigNumber.NewFloat().Mul(v.Fees.TotalFeeRatio, bigNumber.NewFloat(100)).String()+`%`)
+	// }
 
-// 	logs.Success(`Total gains: `, sumOfAllGains.String())
-// 	logs.Success(`Total fees: `, sumOfAllFees.String())
-// 	logs.Success(`Total fee ratio: `, bigNumber.NewFloat().Mul(bigNumber.NewFloat().Div(sumOfAllFees, sumOfAllGains), bigNumber.NewFloat(100)).String()+`%`)
+	// logs.Success(`Total gains: `, sumOfAllGains.String())
+	// logs.Success(`Total fees: `, sumOfAllFees.String())
+	// logs.Success(`Total fee ratio: `, bigNumber.NewFloat().Mul(bigNumber.NewFloat().Div(sumOfAllFees, sumOfAllGains), bigNumber.NewFloat(100)).String()+`%`)
 
-// 	c.JSON(http.StatusOK, internal.AllHarvests[address.Address])
-// }
+	c.JSON(http.StatusOK, allHarvest)
+}
 
 //GetGraph returns a list of blacklisted vaults by the API
 func GetGraph(c *gin.Context) {

--- a/internal/fees/fetcher.go
+++ b/internal/fees/fetcher.go
@@ -1,0 +1,331 @@
+package fees
+
+import (
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/yearn/ydaemon/common/bigNumber"
+	"github.com/yearn/ydaemon/common/contracts"
+	"github.com/yearn/ydaemon/common/ethereum"
+	"github.com/yearn/ydaemon/common/logs"
+	"github.com/yearn/ydaemon/internal/utils"
+)
+
+/**************************************************************************************************
+** Filter all updateManagementFee events and store them in a map of blockNumber => TEventBlock
+**
+** Arguments:
+** - chainID: the chain ID of the network we are working on
+** - vaultAddress: the address of the vault we are working on
+** - vaultActivation: the block number at which the vault was activated
+** - asyncFeeMap: the async ptr to the map of vaultAddress -> blockNumber -> TEventBlock
+** - wg: the async ptr to the WaitGroup to sync the goroutines
+**
+** Returns nothing as the asyncFeeMap is updated via a pointer
+**************************************************************************************************/
+func filterUpdateManagementFee(
+	chainID uint64,
+	vaultAddress common.Address,
+	vaultActivation uint64,
+	asyncFeeMap *sync.Map,
+	wg *sync.WaitGroup,
+) {
+	defer wg.Done()
+	client := ethereum.RPC[chainID]
+
+	currentVault, _ := contracts.NewYvault043(vaultAddress, client)
+	if log, err := currentVault.FilterUpdateManagementFee(&bind.FilterOpts{Start: vaultActivation}); err == nil {
+		for log.Next() {
+			if log.Error() != nil {
+				continue
+			}
+
+			eventKey := vaultAddress.String() + `-` + strconv.FormatUint(uint64(log.Event.Raw.BlockNumber), 10)
+			blockData := utils.TEventBlock{
+				EventType:   `updateManagementFee`,
+				TxHash:      log.Event.Raw.TxHash,
+				BlockNumber: log.Event.Raw.BlockNumber,
+				TxIndex:     log.Event.Raw.TxIndex,
+				LogIndex:    log.Event.Raw.Index,
+				Value:       bigNumber.SetInt(log.Event.ManagementFee),
+			}
+
+			if syncMap, ok := asyncFeeMap.Load(eventKey); ok {
+				currentBlockData := append(syncMap.([]utils.TEventBlock), blockData)
+				asyncFeeMap.Store(eventKey, currentBlockData)
+			} else {
+				asyncFeeMap.Store(eventKey, []utils.TEventBlock{blockData})
+			}
+		}
+	}
+}
+
+/**************************************************************************************************
+** Filter all updatePerformanceFee events and store them in a map of blockNumber => TEventBlock
+**
+** Arguments:
+** - chainID: the chain ID of the network we are working on
+** - vaultAddress: the address of the vault we are working on
+** - vaultActivation: the block number at which the vault was activated
+** - asyncFeeMap: the async ptr to the map of vaultAddress -> blockNumber -> TEventBlock
+** - wg: the async ptr to the WaitGroup to sync the goroutines
+**
+** Returns nothing as the asyncFeeMap is updated via a pointer
+**************************************************************************************************/
+func filterUpdatePerformanceFee(
+	chainID uint64,
+	vaultAddress common.Address,
+	vaultActivation uint64,
+	asyncFeeMap *sync.Map,
+	wg *sync.WaitGroup,
+) {
+	defer wg.Done()
+	client := ethereum.RPC[chainID]
+
+	currentVault, _ := contracts.NewYvault043(vaultAddress, client)
+	if log, err := currentVault.FilterUpdatePerformanceFee(&bind.FilterOpts{Start: vaultActivation}); err == nil {
+		for log.Next() {
+			if log.Error() != nil {
+				continue
+			}
+
+			eventKey := vaultAddress.String() + `-` + strconv.FormatUint(uint64(log.Event.Raw.BlockNumber), 10)
+			blockData := utils.TEventBlock{
+				EventType:   `updatePerformanceFee`,
+				TxHash:      log.Event.Raw.TxHash,
+				BlockNumber: log.Event.Raw.BlockNumber,
+				TxIndex:     log.Event.Raw.TxIndex,
+				LogIndex:    log.Event.Raw.Index,
+				Value:       bigNumber.SetInt(log.Event.PerformanceFee),
+			}
+
+			if syncMap, ok := asyncFeeMap.Load(eventKey); ok {
+				currentBlockData := append(syncMap.([]utils.TEventBlock), blockData)
+				asyncFeeMap.Store(eventKey, currentBlockData)
+			} else {
+				asyncFeeMap.Store(eventKey, []utils.TEventBlock{blockData})
+			}
+		}
+	}
+}
+
+/**************************************************************************************************
+** Filter all updateStrategyPerformanceFee events and store them in a map of blockNumber =>
+** TEventBlock
+**
+** Arguments:
+** - chainID: the chain ID of the network we are working on
+** - vaultAddress: the address of the vault we are working on
+** - vaultActivation: the block number at which the vault was activated
+** - asyncFeeMap: the async ptr to the map of vaultAddr -> strategyAddr -> block -> TEventBlock
+** - wg: the async ptr to the WaitGroup to sync the goroutines
+**
+** Returns nothing as the asyncFeeMap is updated via a pointer
+**************************************************************************************************/
+func filterUpdateStrategyPerformanceFee(
+	chainID uint64,
+	vaultAddress common.Address,
+	vaultActivation uint64,
+	asyncFeeMap *sync.Map,
+	wg *sync.WaitGroup,
+) {
+	defer wg.Done()
+	client := ethereum.RPC[chainID]
+
+	currentVault, _ := contracts.NewYvault043(vaultAddress, client)
+	if log, err := currentVault.FilterStrategyUpdatePerformanceFee(&bind.FilterOpts{Start: vaultActivation}, nil); err == nil {
+		for log.Next() {
+			if log.Error() != nil {
+				continue
+			}
+
+			blockData := utils.TEventBlock{
+				EventType:   "strategyUpdatePerformanceFee",
+				TxHash:      log.Event.Raw.TxHash,
+				BlockNumber: log.Event.Raw.BlockNumber,
+				TxIndex:     log.Event.Raw.TxIndex,
+				LogIndex:    log.Event.Raw.Index,
+				Value:       bigNumber.SetInt(log.Event.PerformanceFee),
+			}
+
+			eventKey := vaultAddress.String() + `-` + log.Event.Strategy.String() + `-` + strconv.FormatUint(uint64(log.Event.Raw.BlockNumber), 10)
+			if syncMap, ok := asyncFeeMap.Load(eventKey); ok {
+				currentBlockData := append((syncMap.([]utils.TEventBlock)), blockData)
+				asyncFeeMap.Store(eventKey, currentBlockData)
+			} else {
+				asyncFeeMap.Store(eventKey, []utils.TEventBlock{blockData})
+			}
+
+		}
+	}
+}
+
+/**************************************************************************************************
+** For each vault we need to know the fee per block, which is the percentage of gains after each
+** harvest that will be sent to the governance. This is a dynamic value, and it can be changed
+** by the governance. We need to fetch all the events of type `UpdateManagementFee`,
+** `UpdateStrategyPerformanceFee` and `UpdatePerformanceFee` and build an historical mapping of
+** the fee per block, knowing for each block which fee to use.
+**
+** Arguments:
+** - chainID: the chain ID of the network we are working on
+** - vaults: the list of vaults we want to fetch the fee for, as a mapping of vaultAddress -> data
+** - strategiesList: the list of strategies we want to fetch the fee for, as a mapping of
+**   vaultAddress -> strategyAddress -> TStrategyAdded. This one is optional to add initial fee to
+**   the strategyPerformanceFee map
+**
+** Returns:
+** - a map of vaultAddress -> blockNumber -> ManagementFee
+** - a map of vaultAddress -> blockNumber -> PerformanceFee
+** - a map of vaultAddress -> strategyAddress -> blockNumber -> PerformanceFee
+**************************************************************************************************/
+func RetrieveAllFeesBPS(
+	chainID uint64,
+	vaults map[common.Address]utils.TVaultsFromRegistry,
+	strategiesLists ...map[common.Address]map[common.Address]utils.TStrategyAdded,
+) (
+	map[common.Address]map[uint64][]utils.TEventBlock,
+	map[common.Address]map[uint64][]utils.TEventBlock,
+	map[common.Address]map[common.Address]map[uint64][]utils.TEventBlock,
+) {
+	timeBefore := time.Now()
+
+	asyncManagementFeeUpdate := sync.Map{}
+	asyncPerformanceFeeUpdate := sync.Map{}
+	asyncStrategiesPerformanceFeeUpdate := sync.Map{}
+
+	wg := &sync.WaitGroup{}
+	for _, v := range vaults {
+		wg.Add(3)
+		go filterUpdateManagementFee(chainID, v.VaultsAddress, v.Activation, &asyncManagementFeeUpdate, wg)
+		go filterUpdatePerformanceFee(chainID, v.VaultsAddress, v.Activation, &asyncPerformanceFeeUpdate, wg)
+		go filterUpdateStrategyPerformanceFee(chainID, v.VaultsAddress, v.Activation, &asyncStrategiesPerformanceFeeUpdate, wg)
+	}
+	wg.Wait()
+
+	/**********************************************************************************************
+	** Once all vaults ManagementFees updates have been retrieved, we need to extract them from the
+	** sync.Map.
+	**
+	** The syncMap variable is setup as follows:
+	** - key: vaultAddress-blockNumber
+	** - value: []TEventBlock
+	**
+	** We need to transform it into a map as follows:
+	** - vaultAddress -> blockNumber -> []TEventBlock
+	**********************************************************************************************/
+	managementFeeForVaults := make(map[common.Address]map[uint64][]utils.TEventBlock)
+	asyncManagementFeeUpdate.Range(func(key, value interface{}) bool {
+		eventKey := strings.Split(key.(string), `-`)
+		vaultAddress := common.HexToAddress(eventKey[0])
+		blockNumber, _ := strconv.ParseUint(eventKey[1], 10, 64)
+
+		if _, ok := managementFeeForVaults[vaultAddress]; !ok {
+			managementFeeForVaults[vaultAddress] = make(map[uint64][]utils.TEventBlock)
+		}
+		managementFeeForVaults[vaultAddress][blockNumber] = value.([]utils.TEventBlock)
+		return true
+	})
+
+	/**********************************************************************************************
+	** Once all vaults PerformanceFees updates have been retrieved, we need to extract them from
+	** the sync.Map.
+	**
+	** The syncMap variable is setup as follows:
+	** - key: vaultAddress-blockNumber
+	** - value: []TEventBlock
+	**
+	** We need to transform it into a map as follows:
+	** - vaultAddress -> blockNumber -> []TEventBlock
+	**********************************************************************************************/
+	performanceFeeForVaults := make(map[common.Address]map[uint64][]utils.TEventBlock)
+	asyncPerformanceFeeUpdate.Range(func(key, value interface{}) bool {
+		eventKey := strings.Split(key.(string), `-`)
+		vaultAddress := common.HexToAddress(eventKey[0])
+		blockNumber, _ := strconv.ParseUint(eventKey[1], 10, 64)
+
+		if _, ok := performanceFeeForVaults[vaultAddress]; !ok {
+			performanceFeeForVaults[vaultAddress] = make(map[uint64][]utils.TEventBlock)
+		}
+		performanceFeeForVaults[vaultAddress][blockNumber] = value.([]utils.TEventBlock)
+		return true
+	})
+
+	/**********************************************************************************************
+	** Once all strategies PerformanceFees updates have been retrieved, we need to extract them
+	** from the sync.Map.
+	**
+	** The syncMap variable is setup as follows:
+	** - key: vaultAddress-strategyAddress-blockNumber
+	** - value: []TEventBlock
+	**
+	** We need to transform it into a map as follows:
+	** - vaultAddress -> strategyAddress -> blockNumber -> []TEventBlock
+	**********************************************************************************************/
+	performanceFeeForStrategies := make(map[common.Address]map[common.Address]map[uint64][]utils.TEventBlock)
+	asyncStrategiesPerformanceFeeUpdate.Range(func(key, value interface{}) bool {
+		eventKey := strings.Split(key.(string), `-`)
+		vaultAddress := common.HexToAddress(eventKey[0])
+		strategyAddress := common.HexToAddress(eventKey[1])
+		blockNumber, _ := strconv.ParseUint(eventKey[2], 10, 64)
+
+		// If the mapping for [vaultAddress] doesn't exist, create it
+		if _, ok := performanceFeeForStrategies[vaultAddress]; !ok {
+			performanceFeeForStrategies[vaultAddress] = make(map[common.Address]map[uint64][]utils.TEventBlock)
+		}
+
+		// If the mapping for [vaultAddress][strategyAddress] doesn't exist, create it
+		if _, ok := performanceFeeForStrategies[vaultAddress][strategyAddress]; !ok {
+			performanceFeeForStrategies[vaultAddress][strategyAddress] = make(map[uint64][]utils.TEventBlock)
+		}
+		// If the mapping for [vaultAddress][strategyAddress][blockNumber] doesn't exist, create it
+		if _, ok := performanceFeeForStrategies[vaultAddress][strategyAddress][blockNumber]; !ok {
+			performanceFeeForStrategies[vaultAddress][strategyAddress][blockNumber] = make([]utils.TEventBlock, 0)
+		}
+
+		performanceFeeForStrategies[vaultAddress][strategyAddress][blockNumber] = value.([]utils.TEventBlock)
+		return true
+	})
+
+	/**********************************************************************************************
+	** The initial strategy performanceFee does not trigger a StrategyPerformanceFeeUpdated event.
+	** Therefore we need to add it from the StrategiesList variable
+	**********************************************************************************************/
+	if len(strategiesLists) == 1 {
+		strategiesList := strategiesLists[0]
+
+		for vaultAddress, strategies := range strategiesList {
+			for strategyAddress, strategy := range strategies {
+				deployEvent := utils.TEventBlock{
+					EventType:   `strategyUpdatePerformanceFee`,
+					TxHash:      strategy.TxHash,
+					BlockNumber: strategy.BlockNumber,
+					TxIndex:     strategy.TxIndex,
+					LogIndex:    strategy.LogIndex,
+					Value:       strategy.PerformanceFee,
+				}
+
+				if _, ok := performanceFeeForStrategies[vaultAddress]; !ok {
+					performanceFeeForStrategies[vaultAddress] = make(map[common.Address]map[uint64][]utils.TEventBlock)
+				}
+				if _, ok := performanceFeeForStrategies[vaultAddress][strategyAddress]; !ok {
+					performanceFeeForStrategies[vaultAddress][strategyAddress] = make(map[uint64][]utils.TEventBlock)
+				}
+				if _, ok := performanceFeeForStrategies[vaultAddress][strategyAddress][strategy.BlockNumber]; !ok {
+					performanceFeeForStrategies[vaultAddress][strategyAddress][strategy.BlockNumber] = make([]utils.TEventBlock, 0)
+				}
+				performanceFeeForStrategies[vaultAddress][strategyAddress][strategy.BlockNumber] = append(
+					performanceFeeForStrategies[vaultAddress][strategyAddress][strategy.BlockNumber],
+					deployEvent,
+				)
+			}
+		}
+	}
+
+	logs.Success(`It took`, time.Since(timeBefore), `to retrieve the fees BPS updates`)
+	return managementFeeForVaults, performanceFeeForVaults, performanceFeeForStrategies
+}

--- a/internal/main.go
+++ b/internal/main.go
@@ -1,0 +1,131 @@
+package internal
+
+import (
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/yearn/ydaemon/common/logs"
+	"github.com/yearn/ydaemon/internal/fees"
+	"github.com/yearn/ydaemon/internal/registries"
+	"github.com/yearn/ydaemon/internal/utils"
+	"github.com/yearn/ydaemon/internal/vaults"
+)
+
+var AllHarvests = make(map[common.Address][]vaults.THarvest)
+
+func Initialize(chainID uint64) {
+	timeBefore := time.Now()
+	/**********************************************************************************************
+	** All vaults from Yearn are registered in the registries contracts. A vault can be either
+	** Standard or Experimental.
+	** From the registries, we are fetching all vaults along with the block in which they were
+	** added to the registry, and we remove the duplicates only to keep the latest version of a
+	** same vault. Duplicate can happen when a vault is moved from Experimental to Standard.
+	**********************************************************************************************/
+	vaultsList := registries.RetrieveAllVaults(chainID)
+
+	strategiesList := map[common.Address]map[common.Address]utils.TStrategyAdded{}
+	transfersFromVaultsToTreasury := map[common.Address]map[uint64][]utils.TEventBlock{}
+	transfersFromVaultsToStrategies := map[common.Address]map[common.Address]map[uint64][]utils.TEventBlock{}
+	managementFees := map[common.Address]map[uint64][]utils.TEventBlock{}
+	performanceFees := map[common.Address]map[uint64][]utils.TEventBlock{}
+	strategiesPerformanceFees := map[common.Address]map[common.Address]map[uint64][]utils.TEventBlock{}
+	allHarvests := map[common.Address]map[common.Address]map[uint64]uint64{}
+
+	/**********************************************************************************************
+	** Fetching all the strategiesList and relevant transfers to proceed
+	**********************************************************************************************/
+	wg := sync.WaitGroup{}
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+
+		/**********************************************************************************************
+		** Retrieve all the strategies ever attached to a vault. This will be used in the next step
+		** to retrieve the transfer events for the strategists fees.
+		** With this process, we are retrieving the standard blockEvents elements and all the arguments
+		** from the `StrategyAdded` event.
+		**********************************************************************************************/
+		strategiesList = vaults.RetrieveAllStrategies(chainID, vaultsList)
+
+		/**********************************************************************************************
+		** Retrieve all transfers from vaults to strategies. This can only happen in one situation: the
+		** vault is sending strategist fees to the strategy for them to be taken by the strategist.
+		** We need that to be able to calculate the strategist fees as many variable could make the
+		** offchain calculation wrong.
+		** Thanks to this number, from offchain totalFees calculation, we can deduct the treasury fees
+		**********************************************************************************************/
+		transfersFromVaultsToStrategies = vaults.RetrieveAllTransferFromVaultsToStrategies(chainID, strategiesList)
+
+		/**********************************************************************************************
+		** For each vault we need to know the fee per block, which is the percentage of gains after each
+		** harvest that will be sent to the governance. This is a dynamic value, and it can be changed
+		** by the governance. We need to fetch all the events of type `UpdateManagementFee`,
+		** `UpdateStrategyPerformanceFee` and `UpdatePerformanceFee` and build an historical mapping of
+		** the fee per block, knowing for each block which fee to use.
+		**********************************************************************************************/
+		managementFees, performanceFees, strategiesPerformanceFees = fees.RetrieveAllFeesBPS(
+			chainID,
+			vaultsList,
+			strategiesList,
+		)
+	}()
+
+	go func() {
+		defer wg.Done()
+		/**********************************************************************************************
+		** Retrieve all transfers from vaults to treasury. This can only happen in one situation: the
+		** vault is sending managements fees to the treasury after a harvest.
+		** We need that to be able to calculate the actual fees as many variable could make the
+		** offchain calculation wrong.
+		**********************************************************************************************/
+		transfersFromVaultsToTreasury = vaults.RetrieveAllTransferFromVaultsToTreasury(chainID, vaultsList)
+	}()
+
+	go func() {
+		defer wg.Done()
+		/**********************************************************************************************
+		** Retrieve all harvest events for a vault. This will enable us to know where to look and to
+		** compute the gains, losses and the fees.
+		**********************************************************************************************/
+		allHarvests = vaults.RetrieveHarvests(chainID, vaultsList)
+	}()
+	wg.Wait()
+
+	logs.Success("Initialization done in", time.Since(timeBefore))
+
+	timeBefore = time.Now()
+	syncGroup := &sync.WaitGroup{}
+	harvests := []vaults.THarvest{}
+	for _, vault := range vaultsList {
+		switch vault.APIVersion {
+		case `0.2.2`:
+		case `0.3.0`:
+			continue //SKIP
+		case `0.3.1`, `0.3.2`, `0.3.3`, `0.3.4`, `0.3.5`, `0.4.2`, `0.4.3`:
+			syncGroup.Add(1)
+			go vaults.HandleEvenStrategyReportedFor031To043(
+				chainID,
+				vault,
+				managementFees[vault.VaultsAddress],
+				performanceFees[vault.VaultsAddress],
+				strategiesPerformanceFees[vault.VaultsAddress],
+				transfersFromVaultsToStrategies[vault.VaultsAddress],
+				transfersFromVaultsToTreasury[vault.VaultsAddress],
+				allHarvests[vault.VaultsAddress],
+				syncGroup,
+				&harvests,
+			)
+		}
+	}
+	syncGroup.Wait()
+
+	count := 0
+	for _, v := range harvests {
+		AllHarvests[v.Vault] = append(AllHarvests[v.Vault], v)
+		count++
+	}
+
+	logs.Success(`It took`, time.Since(timeBefore), `to process`, count, `harvests`)
+}

--- a/internal/registries/fetcher.go
+++ b/internal/registries/fetcher.go
@@ -10,6 +10,7 @@ import (
 	"github.com/yearn/ydaemon/common/ethereum"
 	"github.com/yearn/ydaemon/common/logs"
 	"github.com/yearn/ydaemon/internal/utils"
+	"github.com/yearn/ydaemon/internal/vaults"
 )
 
 type TRegistry struct {
@@ -185,5 +186,5 @@ func RetrieveAllVaults(
 	}
 
 	logs.Success(`It took`, time.Since(timeBefore), `to retrieve`, len(uniqueVaultsList), `vaults`)
-	return uniqueVaultsList
+	return vaults.RetrieveActivationForAllVaults(chainID, uniqueVaultsList)
 }

--- a/internal/utils/blocks.go
+++ b/internal/utils/blocks.go
@@ -1,0 +1,144 @@
+package utils
+
+import (
+	"errors"
+	"sort"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/yearn/ydaemon/common/bigNumber"
+	"github.com/yearn/ydaemon/common/logs"
+)
+
+type TEventBlock struct {
+	EventType   string
+	TxHash      common.Hash
+	BlockNumber uint64
+	TxIndex     uint
+	LogIndex    uint
+	Value       *bigNumber.Int
+}
+
+/**************************************************************************************************
+** findInBlock try to find the event in the block that matches the txIndex and logIndex.
+** All events are in the same block. We need to find the one before or equal to the provided
+** txIndex and, if the txIndex is the same, the one before or equal to the provided logIndex.
+**************************************************************************************************/
+func findInBlock(blocks []TEventBlock, lookingForTxIndex uint, lookingForLogIndex uint) (TEventBlock, error) {
+	/**********************************************************************************************
+	** Blocks are not ordered by txIndex and logIndex, so we need to sort them first while removing
+	** all events that are after the one we are looking for (txIndex > lookingForTxIndex)
+	**********************************************************************************************/
+	blockEvents := []TEventBlock{}
+	for _, block := range blocks {
+		if block.TxIndex > lookingForTxIndex {
+			continue
+		}
+		blockEvents = append(blockEvents, block)
+	}
+
+	/**********************************************************************************************
+	** If we have no events left, we can't find the one we are looking for
+	**********************************************************************************************/
+	if len(blockEvents) == 0 {
+		return TEventBlock{}, errors.New("no event found")
+	}
+
+	/**********************************************************************************************
+	** Sort the events by txIndex and logIndex, with the highest txIndex first and the highest
+	** logIndex first
+	**********************************************************************************************/
+	sort.Slice(blockEvents, func(i, j int) bool {
+		if blockEvents[i].TxIndex == blockEvents[j].TxIndex {
+			return blockEvents[i].LogIndex > blockEvents[j].LogIndex
+		}
+		return blockEvents[i].TxIndex > blockEvents[j].TxIndex
+	})
+
+	for _, event := range blockEvents {
+		if event.TxIndex < lookingForTxIndex {
+			return event, nil
+		} else if event.TxIndex == lookingForTxIndex && event.LogIndex <= lookingForLogIndex {
+			return event, nil
+		}
+	}
+	return TEventBlock{}, errors.New(`no previous block found`)
+}
+
+/**************************************************************************************************
+** analyzeBlocks will, for a given TEventBlock mapping, try to find the block just before the block
+** that matches the blockNumber, txIndex and logIndex of the event. If it finds it, it will return
+** it. If it doesn't find it, it will return an empty TEventBlock.
+**************************************************************************************************/
+func analyzeBlocks(m map[uint64][]TEventBlock, lookingForBlock uint64, lookingForTxIndex uint, lookingForLogIndex uint) TEventBlock {
+	/**********************************************************************************************
+	** First step is to order all blocks by blockNumber, from the highest to the lowest (last
+	** first) and remove all thooses that are higher than the blockNumber of the event.
+	**********************************************************************************************/
+	blockNumbers := make([]int, 0, len(m))
+	for k := range m {
+		if k <= lookingForBlock {
+			blockNumbers = append(blockNumbers, int(k))
+		}
+	}
+	sort.Sort(sort.Reverse(sort.IntSlice(blockNumbers)))
+	if len(blockNumbers) == 0 {
+		return TEventBlock{}
+	}
+
+	/**********************************************************************************************
+	** Then, we have two cases:
+	** 1. The blockNumber of the event is in the map. In this case, we need to find, in the list of
+	**    events of this block, the one with a txIndex just before the one of the event then a
+	**    logIndex just before the one of the event.
+	** 2. The blockNumber of the event is not in the map. In this case, we need to find the block
+	**    just before the one of the event.
+	**********************************************************************************************/
+	if blockNumbers[0] == int(lookingForBlock) {
+		//case 1
+		blocks := m[lookingForBlock]
+		block, err := findInBlock(blocks, lookingForTxIndex, lookingForLogIndex)
+		if err != nil {
+			return TEventBlock{}
+		}
+		return block
+	} else {
+		//case 2
+		blocks := m[uint64(blockNumbers[0])]
+		block, err := findInBlock(blocks, ^uint(0), ^uint(0))
+		if err != nil {
+			logs.Error(`NOT FOUND`)
+			return TEventBlock{}
+		}
+		return block
+	}
+}
+
+/**************************************************************************************************
+** FindEventBefore will, for a given TEventBlock mapping, try to find the value amount to use for
+** this block. This is done by analyzing all fee change event and determining which one is the
+** most recent one based on the event sent as parameter.
+**************************************************************************************************/
+func FindEventBefore(feeUpdatesBlocks map[uint64][]TEventBlock, eventBlock TEventBlock) *bigNumber.Int {
+	previousBlocks := analyzeBlocks(feeUpdatesBlocks, eventBlock.BlockNumber, eventBlock.TxIndex, eventBlock.LogIndex)
+	return previousBlocks.Value
+}
+
+/**************************************************************************************************
+** FindPreviousBlock will, for a given blockNumber mapping, try to find the blockNumber just before
+** and return it. If it can't find it, it will return 0.
+**************************************************************************************************/
+func FindPreviousBlock(blocks map[uint64]uint64, blockNumber uint64) (previous uint64) {
+	keys := make([]int, 0, len(blocks))
+	for k := range blocks {
+		keys = append(keys, int(k))
+	}
+	sort.Ints(keys)
+
+	for _, k := range keys {
+		if k >= int(blockNumber) {
+			return
+		}
+		previous = blocks[uint64(k)]
+	}
+	return
+}

--- a/internal/utils/events.go
+++ b/internal/utils/events.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/yearn/ydaemon/common/bigNumber"
 )
 
 type TVaultsFromRegistry struct {
@@ -16,4 +17,29 @@ type TVaultsFromRegistry struct {
 	ManagementFee   uint64
 	TxIndex         uint
 	LogIndex        uint
+}
+
+type TStrategyAdded struct {
+	VaultAddress      common.Address
+	StrategyAddress   common.Address
+	TxHash            common.Hash
+	DebtRatio         *bigNumber.Int // >= 0.3.0
+	MaxDebtPerHarvest *bigNumber.Int // >= 0.3.2
+	MinDebtPerHarvest *bigNumber.Int // >= 0.3.2
+	PerformanceFee    *bigNumber.Int // >= 0.2.2
+	DebtLimit         *bigNumber.Int // == 0.2.2
+	RateLimit         *bigNumber.Int // == 0.2.2 - 0.3.0
+	BlockNumber       uint64
+	TxIndex           uint
+	LogIndex          uint
+}
+
+type TStrategyMigrated struct {
+	VaultAddress       common.Address
+	OldStrategyAddress common.Address
+	NewStrategyAddress common.Address
+	TxHash             common.Hash
+	BlockNumber        uint64
+	TxIndex            uint
+	LogIndex           uint
 }

--- a/internal/vaults/events.harvests.go
+++ b/internal/vaults/events.harvests.go
@@ -1,0 +1,122 @@
+package vaults
+
+import (
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/yearn/ydaemon/common/contracts"
+	"github.com/yearn/ydaemon/common/ethereum"
+	"github.com/yearn/ydaemon/common/logs"
+	"github.com/yearn/ydaemon/internal/utils"
+)
+
+/**************************************************************************************************
+** Filter all transfer events to retrieve the transfer value and store it in an array of
+** TEventBlock
+**
+** Arguments:
+** - chainID: the chain ID of the network we are working on
+** - vaultAddress: the address of the vault we are working on
+** - activation: the block number at which the strategy was activated
+** - asyncMapLastReports: the ptr to the async map to store the blockTimestamp
+** - wg: the async ptr to the WaitGroup to sync the goroutines
+**
+** Returns nothing as asyncMapLastReports is updated via a pointer
+**************************************************************************************************/
+func filterStrategyReported(
+	chainID uint64,
+	vaultAddress common.Address,
+	activation uint64,
+	asyncMapLastReports *sync.Map,
+	wg *sync.WaitGroup,
+) {
+	defer wg.Done()
+
+	client := ethereum.RPC[chainID]
+	currentVault, _ := contracts.NewYvault043(vaultAddress, client)
+	if log, err := currentVault.FilterStrategyReported(&bind.FilterOpts{Start: activation}, nil); err == nil {
+		for log.Next() {
+			if log.Error() != nil {
+				continue
+			}
+			blockTimestamp := ethereum.GetBlockTime(chainID, log.Event.Raw.BlockNumber)
+			eventKey := (vaultAddress.String() + `-` +
+				log.Event.Strategy.String() + `-` +
+				strconv.FormatUint(log.Event.Raw.BlockNumber, 10))
+			asyncMapLastReports.LoadOrStore(eventKey, blockTimestamp)
+		}
+	}
+}
+
+/**********************************************************************************************
+** Retrieve all transfers from vaults to strategies. This can only happen in one situation: the
+** vault is sending strategist fees to the strategy for them to be taken by the strategist.
+** We need that to be able to calculate the strategist fees as many variable could make the
+** offchain calculation wrong.
+** Thanks to this number, from offchain totalFees calculation, we can deduct the treasury fees.
+**
+** Arguments:
+** - chainID: the chain ID of the network we are working on
+** - strategies: list of all TStrategyAdded to work on
+**
+** Returns:
+** - a map of vaultAddress -> strategyAddress -> blockNumber -> TEventBlock
+**********************************************************************************************/
+func RetrieveHarvests(
+	chainID uint64,
+	vaults map[common.Address]utils.TVaultsFromRegistry,
+) map[common.Address]map[common.Address]map[uint64]uint64 {
+	timeBefore := time.Now()
+
+	/**********************************************************************************************
+	** Concurrently retrieve all strategyReported from vaults to strategies, waiting for the end
+	** of all goroutines via the wg before continuing.
+	**********************************************************************************************/
+	asyncMapLastReports := sync.Map{}
+	wg := &sync.WaitGroup{}
+	for _, v := range vaults {
+		wg.Add(1)
+		go filterStrategyReported(
+			chainID,
+			v.VaultsAddress,
+			v.Activation,
+			&asyncMapLastReports,
+			wg,
+		)
+	}
+	wg.Wait()
+
+	/**********************************************************************************************
+	** Once all transfers from vaults to strategies have been retrieved, we need to extract them
+	** from the sync.Map.
+	**
+	** The syncMap variable is setup as follows:
+	** - key: vaultAddress-strategyAddress-blockNumber
+	** - value: []TEventBlock
+	**********************************************************************************************/
+	count := 0
+	lastReportForStrategy := make(map[common.Address]map[common.Address]map[uint64]uint64)
+	asyncMapLastReports.Range(func(key, value interface{}) bool {
+		eventKey := strings.Split(key.(string), `-`)
+		vaultAddressParsed := common.HexToAddress(eventKey[0])
+		strategyAddressParsed := common.HexToAddress(eventKey[1])
+		blockNumber, _ := strconv.ParseUint(eventKey[2], 10, 64)
+
+		if _, ok := lastReportForStrategy[vaultAddressParsed]; !ok {
+			lastReportForStrategy[vaultAddressParsed] = make(map[common.Address]map[uint64]uint64)
+		}
+		if _, ok := lastReportForStrategy[vaultAddressParsed][strategyAddressParsed]; !ok {
+			lastReportForStrategy[vaultAddressParsed][strategyAddressParsed] = make(map[uint64]uint64)
+		}
+		lastReportForStrategy[vaultAddressParsed][strategyAddressParsed][blockNumber] = value.(uint64)
+		count++
+		return true
+	})
+
+	logs.Success(`It took`, time.Since(timeBefore), `to retrieve`, count, `reports`)
+	return lastReportForStrategy
+}

--- a/internal/vaults/events.strategies.go
+++ b/internal/vaults/events.strategies.go
@@ -1,0 +1,271 @@
+package vaults
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/yearn/ydaemon/common/bigNumber"
+	"github.com/yearn/ydaemon/common/contracts"
+	"github.com/yearn/ydaemon/common/ethereum"
+	"github.com/yearn/ydaemon/common/logs"
+	"github.com/yearn/ydaemon/internal/utils"
+)
+
+/**************************************************************************************************
+** Filter all strategiesMigrated events. Theses events are then stored in a map for easy access:
+** vaultAddress-oldAddress-newAddress => TEventBlock.
+**
+** Arguments:
+** - chainID: the chain ID of the network we are working on
+** - vaultAddress: the address of the vault we are working on
+** - vaultActivation: the block number at which the vault was activated
+** - asyncStrategiesMigration: the async ptr to the map of vaultAddr -> oldStrategyAddr ->
+**   newStrategyAddr -> TStrategyMigrated
+** - wg: the async ptr to the WaitGroup to sync the goroutines
+**
+** Returns nothing as the asyncFeeMap is updated via a pointer
+**************************************************************************************************/
+func getStrategiesMigrated(
+	chainID uint64,
+	vaultAddress common.Address,
+	vaultActivation uint64,
+	asyncStrategiesMigration *sync.Map,
+	wg *sync.WaitGroup,
+) {
+	defer wg.Done()
+
+	client := ethereum.RPC[chainID]
+	vault, _ := contracts.NewYvault043(vaultAddress, client)
+	if log, err := vault.FilterStrategyMigrated(&bind.FilterOpts{Start: vaultActivation}, nil, nil); err == nil {
+		for log.Next() {
+			if log.Error() != nil {
+				continue
+			}
+			oldAddress := log.Event.OldVersion
+			newAddress := log.Event.NewVersion
+
+			eventKey := vaultAddress.String() + `-` + oldAddress.String() + `-` + newAddress.String()
+			asyncStrategiesMigration.Store(eventKey, utils.TStrategyMigrated{
+				VaultAddress:       vaultAddress,
+				OldStrategyAddress: oldAddress,
+				NewStrategyAddress: newAddress,
+				TxHash:             log.Event.Raw.TxHash,
+				BlockNumber:        log.Event.Raw.BlockNumber,
+				TxIndex:            log.Event.Raw.TxIndex,
+				LogIndex:           log.Event.Raw.Index,
+			})
+		}
+	}
+}
+
+/**************************************************************************************************
+** Filter all StrategyAdded events and store them in a map of vaultAddress-strategyAddress
+** => TEventBlock
+** Version [0.2.2] - [0.3.0 & 0.3.1] - [>= 0.3.2] have different events structure and thus need
+** to be handled differently.
+**
+** Arguments:
+** - chainID: the chain ID of the network we are working on
+** - vaultAddress: the address of the vault we are working on
+** - vaultActivation: the block number at which the vault was activated
+** - asyncStrategiesForVaults: the async ptr to the map of vaultAddr -> strategyAddr -> blockNumber
+**   -> TEventBlock
+** - wg: the async ptr to the WaitGroup to sync the goroutines
+**
+** Returns nothing as the asyncFeeMap is updated via a pointer
+**************************************************************************************************/
+func getStrategiesAdded(
+	chainID uint64,
+	vaultAddress common.Address,
+	vaultActivation uint64,
+	vaultVersion string,
+	asyncStrategiesForVaults *sync.Map,
+	wg *sync.WaitGroup,
+) {
+	defer wg.Done()
+
+	client := ethereum.RPC[chainID]
+	switch vaultVersion {
+	case `0.2.2`:
+		vault, _ := contracts.NewYvault022(vaultAddress, client)
+		if log, err := vault.FilterStrategyAdded(&bind.FilterOpts{Start: vaultActivation}, nil); err == nil {
+			for log.Next() {
+				if log.Error() != nil {
+					continue
+				}
+				eventKey := vaultAddress.String() + `-` + log.Event.Strategy.String()
+				asyncStrategiesForVaults.Store(eventKey, utils.TStrategyAdded{
+					VaultAddress:    vaultAddress,
+					StrategyAddress: log.Event.Strategy,
+					TxHash:          log.Event.Raw.TxHash,
+					BlockNumber:     log.Event.Raw.BlockNumber,
+					TxIndex:         log.Event.Raw.TxIndex,
+					LogIndex:        log.Event.Raw.Index,
+					DebtLimit:       bigNumber.SetInt(log.Event.DebtLimit),
+					RateLimit:       bigNumber.SetInt(log.Event.RateLimit),
+					PerformanceFee:  bigNumber.SetInt(log.Event.PerformanceFee),
+				})
+			}
+		}
+	case `0.3.0`, `0.3.1`:
+		vault, _ := contracts.NewYvault030(vaultAddress, client)
+		if log, err := vault.FilterStrategyAdded(&bind.FilterOpts{Start: vaultActivation}, nil); err == nil {
+			for log.Next() {
+				if log.Error() != nil {
+					continue
+				}
+				eventKey := vaultAddress.String() + `-` + log.Event.Strategy.String()
+				asyncStrategiesForVaults.Store(eventKey, utils.TStrategyAdded{
+					VaultAddress:    vaultAddress,
+					StrategyAddress: log.Event.Strategy,
+					TxHash:          log.Event.Raw.TxHash,
+					BlockNumber:     log.Event.Raw.BlockNumber,
+					TxIndex:         log.Event.Raw.TxIndex,
+					LogIndex:        log.Event.Raw.Index,
+					DebtRatio:       bigNumber.SetInt(log.Event.DebtRatio),
+					RateLimit:       bigNumber.SetInt(log.Event.RateLimit),
+					PerformanceFee:  bigNumber.SetInt(log.Event.PerformanceFee),
+				})
+			}
+		}
+	case `0.3.2`, `0.3.3`, `0.3.4`, `0.3.5`, `0.4.2`, `0.4.3`:
+		vault, _ := contracts.NewYvault043(vaultAddress, client)
+		if log, err := vault.FilterStrategyAdded(&bind.FilterOpts{Start: vaultActivation}, nil); err == nil {
+			for log.Next() {
+				if log.Error() != nil {
+					continue
+				}
+
+				eventKey := vaultAddress.String() + `-` + log.Event.Strategy.String()
+				asyncStrategiesForVaults.Store(eventKey, utils.TStrategyAdded{
+					VaultAddress:      vaultAddress,
+					StrategyAddress:   log.Event.Strategy,
+					TxHash:            log.Event.Raw.TxHash,
+					BlockNumber:       log.Event.Raw.BlockNumber,
+					TxIndex:           log.Event.Raw.TxIndex,
+					LogIndex:          log.Event.Raw.Index,
+					DebtRatio:         bigNumber.SetInt(log.Event.DebtRatio),
+					MaxDebtPerHarvest: bigNumber.SetInt(log.Event.MaxDebtPerHarvest),
+					MinDebtPerHarvest: bigNumber.SetInt(log.Event.MinDebtPerHarvest),
+					PerformanceFee:    bigNumber.SetInt(log.Event.PerformanceFee),
+				})
+			}
+		}
+	}
+}
+
+/**********************************************************************************************
+** Once we got all the vaults, we can track the events linked to the strategies to be able to
+** get the corresponding data. Events are not the same for all the vaults versions, but should
+** have some common data.
+** Not all events are required and the minimal configuration to get the vaults is the
+** StrategyAdded event.
+**
+** Other possible events:
+** StrategyReported | StrategyUpdateDebtRatio | StrategyUpdateMinDebtPerHarvest |
+** StrategyUpdateMaxDebtPerHarvest | StrategyMigrated | StrategyRevoked |
+** StrategyUpdatePerformanceFee | StrategyRemovedFromQueue | StrategyAddedToQueue
+**********************************************************************************************/
+func RetrieveAllStrategies(
+	chainID uint64,
+	vaults map[common.Address]utils.TVaultsFromRegistry,
+) map[common.Address]map[common.Address]utils.TStrategyAdded {
+	timeBefore := time.Now()
+
+	asyncStrategiesForVaults := &sync.Map{}
+	asyncStrategiesMigrated := &sync.Map{}
+
+	wg := &sync.WaitGroup{}
+	for _, v := range vaults {
+		wg.Add(2)
+		go getStrategiesAdded(
+			chainID,
+			v.VaultsAddress,
+			v.Activation,
+			v.APIVersion,
+			asyncStrategiesForVaults,
+			wg,
+		)
+		go getStrategiesMigrated(
+			chainID,
+			v.VaultsAddress,
+			v.Activation,
+			asyncStrategiesMigrated,
+			wg,
+		)
+	}
+	wg.Wait()
+
+	/**********************************************************************************************
+	** Once all vaults StrategyAdded updates have been retrieved, we need to extract them from the
+	** sync.Map.
+	**
+	** The syncMap variable is setup as follows:
+	** - key: vaultAddress-strategyAddress
+	** - value: []TStrategyAdded
+	**
+	** We need to transform it into a map as follows:
+	** - vaultAddress -> strategyAddress -> []TEventBlock
+	**********************************************************************************************/
+	count := 0
+	strategies := make(map[common.Address]map[common.Address]utils.TStrategyAdded)
+	asyncStrategiesForVaults.Range(func(key, value interface{}) bool {
+		eventKey := strings.Split(key.(string), `-`)
+		vaultAddressParsed := common.HexToAddress(eventKey[0])
+		strategyAddressParsed := common.HexToAddress(eventKey[1])
+
+		if _, ok := strategies[vaultAddressParsed]; !ok {
+			strategies[vaultAddressParsed] = make(map[common.Address]utils.TStrategyAdded)
+		}
+		strategies[vaultAddressParsed][strategyAddressParsed] = value.(utils.TStrategyAdded)
+		count++
+		return true
+	})
+
+	/**********************************************************************************************
+	** Once all vaults StrategyMigrated updates have been retrieved, we need to extract them from
+	** the sync.Map to append them to the strategies map. Theses strategies should use the last
+	** state of the previous strategy in order to keep the data consistent.
+	**
+	** The syncMap variable is setup as follows:
+	** - key: vaultAddress-oldStrategyAddress-newStrategyAddress
+	** - value: []TStrategyMigrated
+	**
+	** We need to transform it into a map as follows:
+	** - vaultAddress -> strategyAddress -> []TEventBlock
+	**********************************************************************************************/
+	asyncStrategiesMigrated.Range(func(key, value interface{}) bool {
+		eventKey := strings.Split(key.(string), `-`)
+		vaultAddressParsed := common.HexToAddress(eventKey[0])
+		oldStrategyAddressParsed := common.HexToAddress(eventKey[1])
+		newStrategyAddressParsed := common.HexToAddress(eventKey[2])
+
+		if _, ok := strategies[vaultAddressParsed]; !ok {
+			strategies[vaultAddressParsed] = make(map[common.Address]utils.TStrategyAdded)
+		}
+		oldStrategy := strategies[vaultAddressParsed][oldStrategyAddressParsed]
+		newStrategy := utils.TStrategyAdded{
+			VaultAddress:      vaultAddressParsed,
+			StrategyAddress:   newStrategyAddressParsed,
+			TxHash:            value.(utils.TStrategyMigrated).TxHash,
+			DebtRatio:         oldStrategy.DebtRatio,
+			MaxDebtPerHarvest: oldStrategy.MaxDebtPerHarvest,
+			MinDebtPerHarvest: oldStrategy.MinDebtPerHarvest,
+			PerformanceFee:    oldStrategy.PerformanceFee,
+			DebtLimit:         oldStrategy.DebtLimit,
+			RateLimit:         oldStrategy.RateLimit,
+			BlockNumber:       value.(utils.TStrategyMigrated).BlockNumber,
+			TxIndex:           value.(utils.TStrategyMigrated).TxIndex,
+			LogIndex:          value.(utils.TStrategyMigrated).LogIndex,
+		}
+		strategies[vaultAddressParsed][newStrategyAddressParsed] = newStrategy
+		count++
+		return true
+	})
+
+	logs.Success(`It took`, time.Since(timeBefore), `to retrieve`, count, `strategies`)
+	return strategies
+}

--- a/internal/vaults/events.transfers.go
+++ b/internal/vaults/events.transfers.go
@@ -1,0 +1,240 @@
+package vaults
+
+import (
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/yearn/ydaemon/common/bigNumber"
+	"github.com/yearn/ydaemon/common/contracts"
+	"github.com/yearn/ydaemon/common/ethereum"
+	"github.com/yearn/ydaemon/common/logs"
+	"github.com/yearn/ydaemon/internal/utils"
+)
+
+/**************************************************************************************************
+** Filter all transfer events to retrieve the transfer value and store it in an array of
+** TEventBlock
+**
+** Arguments:
+** - chainID: the chain ID of the network we are working on
+** - vaultAddress: the address of the vault we are working on
+** - fromAddresses: array of FROM addresses to filter on
+** - toAddresses: array of TO addresses to filter on
+** - activation: the block number at which the strategy was activated
+** - asyncMapTransfers: the ptr to the async map to store the TEventBlock
+** - wg: the async ptr to the WaitGroup to sync the goroutines
+**
+** Returns nothing as asyncMapTransfers is updated via a pointer
+**************************************************************************************************/
+func filterTransfers(
+	chainID uint64,
+	vaultAddress common.Address,
+	fromAddresses []common.Address,
+	toAddresses []common.Address,
+	activation uint64,
+	asyncMapTransfers *sync.Map,
+	wg *sync.WaitGroup,
+) {
+	defer wg.Done()
+
+	client := ethereum.RPC[chainID]
+	currentVault, _ := contracts.NewYvault043(vaultAddress, client)
+	if log, err := currentVault.FilterTransfer(
+		&bind.FilterOpts{Start: activation},
+		fromAddresses,
+		toAddresses,
+	); err == nil {
+		for log.Next() {
+			if log.Error() != nil {
+				continue
+			}
+			eventKey := (log.Event.Sender.String() + `-` +
+				log.Event.Receiver.String() + `-` +
+				strconv.FormatUint(uint64(log.Event.Raw.BlockNumber), 10))
+
+			blockData := utils.TEventBlock{
+				EventType:   `transfer`,
+				TxHash:      log.Event.Raw.TxHash,
+				BlockNumber: log.Event.Raw.BlockNumber,
+				TxIndex:     log.Event.Raw.TxIndex,
+				LogIndex:    log.Event.Raw.Index,
+				Value:       bigNumber.SetInt(log.Event.Value),
+			}
+
+			if syncMap, ok := asyncMapTransfers.Load(eventKey); ok {
+				currentBlockData := append((syncMap.([]utils.TEventBlock)), blockData)
+				asyncMapTransfers.Store(eventKey, currentBlockData)
+			} else {
+				asyncMapTransfers.Store(eventKey, []utils.TEventBlock{blockData})
+			}
+		}
+	}
+}
+
+/**********************************************************************************************
+** Retrieve all transfers from vaults to strategies. This can only happen in one situation: the
+** vault is sending strategist fees to the strategy for them to be taken by the strategist.
+** We need that to be able to calculate the strategist fees as many variable could make the
+** offchain calculation wrong.
+** Thanks to this number, from offchain totalFees calculation, we can deduct the treasury fees.
+**
+** Arguments:
+** - chainID: the chain ID of the network we are working on
+** - strategies: list of all TStrategyAdded to work on
+**
+** Returns:
+** - a map of vaultAddress -> strategyAddress -> blockNumber -> TEventBlock
+**********************************************************************************************/
+func RetrieveAllTransferFromVaultsToStrategies(
+	chainID uint64,
+	strategies map[common.Address]map[common.Address]utils.TStrategyAdded,
+) map[common.Address]map[common.Address]map[uint64][]utils.TEventBlock {
+	timeBefore := time.Now()
+
+	/**********************************************************************************************
+	** Concurrently retrieve all transfers from vaults to strategies, waiting for the end of all
+	** goroutines via the wg before continuing.
+	**********************************************************************************************/
+	syncMap := &sync.Map{}
+	wg := &sync.WaitGroup{}
+	for _, vault := range strategies {
+		for _, strategy := range vault {
+			wg.Add(1)
+			go filterTransfers(
+				chainID,
+				strategy.VaultAddress,
+				[]common.Address{strategy.VaultAddress},
+				[]common.Address{strategy.StrategyAddress},
+				strategy.BlockNumber,
+				syncMap,
+				wg,
+			)
+		}
+	}
+	wg.Wait()
+
+	/**********************************************************************************************
+	** Once all transfers from vaults to strategies have been retrieved, we need to extract them
+	** from the sync.Map.
+	**
+	** The syncMap variable is setup as follows:
+	** - key: vaultAddress-strategyAddress-blockNumber
+	** - value: []TEventBlock
+	**********************************************************************************************/
+	count := 0
+	asyncMapTransfers := make(map[common.Address]map[common.Address]map[uint64][]utils.TEventBlock)
+	syncMap.Range(func(key, value interface{}) bool {
+		eventKey := strings.Split(key.(string), `-`)
+		vaultAddress := common.HexToAddress(eventKey[0])
+		strategyAddress := common.HexToAddress(eventKey[1])
+		blockNumber, _ := strconv.ParseUint(eventKey[2], 10, 64)
+
+		// If the mapping for [vaultAddress] doesn't exist, create it
+		if _, ok := asyncMapTransfers[vaultAddress]; !ok {
+			asyncMapTransfers[vaultAddress] = make(map[common.Address]map[uint64][]utils.TEventBlock)
+		}
+
+		// If the mapping for [vaultAddress][strategyAddress] doesn't exist, create it
+		if _, ok := asyncMapTransfers[vaultAddress][strategyAddress]; !ok {
+			asyncMapTransfers[vaultAddress][strategyAddress] = make(map[uint64][]utils.TEventBlock)
+		}
+
+		// If the mapping for [vaultAddress][strategyAddress][blockNumber] doesn't exist, create it
+		if _, ok := asyncMapTransfers[vaultAddress][strategyAddress][blockNumber]; !ok {
+			asyncMapTransfers[vaultAddress][strategyAddress][blockNumber] = make([]utils.TEventBlock, 0)
+		}
+
+		asyncMapTransfers[vaultAddress][strategyAddress][blockNumber] = append(
+			asyncMapTransfers[vaultAddress][strategyAddress][blockNumber],
+			value.([]utils.TEventBlock)...,
+		)
+		count++
+		return true
+	})
+
+	logs.Success(`It took`, time.Since(timeBefore), `to retrieve`, count, `transfers from vaults to strategies`)
+	return asyncMapTransfers
+}
+
+/**********************************************************************************************
+** Retrieve all transfers from vaults to treasury. This can only happen in one situation: the
+** vault is sending managements fees to the treasury after a harvest.
+** We need that to be able to calculate the actual fees as many variable could make the
+** offchain calculation wrong.
+**
+** Arguments:
+** - chainID: the chain ID of the network we are working on
+** - vaults: list of all the vaults to work on
+**
+** Returns:
+** - a map of vaultAddress -> blockNumber -> TEventBlock
+**********************************************************************************************/
+func RetrieveAllTransferFromVaultsToTreasury(
+	chainID uint64,
+	vaults map[common.Address]utils.TVaultsFromRegistry,
+) map[common.Address]map[uint64][]utils.TEventBlock {
+	timeBefore := time.Now()
+
+	/**********************************************************************************************
+	** Concurrently retrieve all transfers from vaults to strategies, waiting for the end of all
+	** goroutines via the syncGroup before continuing.
+	**********************************************************************************************/
+	treasury := common.HexToAddress(`0x93a62da5a14c80f265dabc077fcee437b1a0efde`)
+	logs.Warning(`using generic treasury address`)
+
+	syncMap := &sync.Map{}
+	wg := &sync.WaitGroup{}
+	for _, vault := range vaults {
+		wg.Add(1)
+		go filterTransfers(
+			chainID,
+			vault.VaultsAddress,
+			[]common.Address{vault.VaultsAddress},
+			[]common.Address{treasury}, //TODO: add vaults that have a different treasury address
+			vault.Activation,
+			syncMap,
+			wg,
+		)
+	}
+	wg.Wait()
+
+	/**********************************************************************************************
+	** Once all transfers from vaults to treasury have been retrieved, we need to extract them
+	** from the sync.Map.
+	**
+	** The syncMap variable is setup as follows:
+	** - key: vaultAddress-blockNumber
+	** - value: []TEventBlock
+	**********************************************************************************************/
+	count := 0
+	transfersFromVaultsToStrategies := make(map[common.Address]map[uint64][]utils.TEventBlock)
+	syncMap.Range(func(key, value interface{}) bool {
+		eventKey := strings.Split(key.(string), `-`)
+		senderAddress := common.HexToAddress(eventKey[0])
+		blockNumber, _ := strconv.ParseUint(eventKey[2], 10, 64)
+
+		// If the mapping for [senderAddress] doesn't exist, create it
+		if _, ok := transfersFromVaultsToStrategies[senderAddress]; !ok {
+			transfersFromVaultsToStrategies[senderAddress] = make(map[uint64][]utils.TEventBlock)
+		}
+
+		// If the mapping for [senderAddress][blockNumber] doesn't exist, create it
+		if _, ok := transfersFromVaultsToStrategies[senderAddress][blockNumber]; !ok {
+			transfersFromVaultsToStrategies[senderAddress][blockNumber] = make([]utils.TEventBlock, 0)
+		}
+
+		transfersFromVaultsToStrategies[senderAddress][blockNumber] = append(
+			transfersFromVaultsToStrategies[senderAddress][blockNumber],
+			value.([]utils.TEventBlock)...,
+		)
+		count++
+		return true
+	})
+
+	logs.Success(`It took`, time.Since(timeBefore), `to retrieve`, count, `transfers from vaults to treasury`)
+	return transfersFromVaultsToStrategies
+}

--- a/internal/vaults/fetcher.go
+++ b/internal/vaults/fetcher.go
@@ -1,0 +1,102 @@
+package vaults
+
+import (
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/yearn/ydaemon/common/contracts"
+	"github.com/yearn/ydaemon/common/ethereum"
+	"github.com/yearn/ydaemon/common/logs"
+	"github.com/yearn/ydaemon/internal/utils"
+)
+
+/**************************************************************************************************
+** Filter only the first UpdateManagement events to know when it was emitted and extract the
+** blockNumber.
+**
+** Arguments:
+** - chainID: the chain ID of the network we are working on
+** - vaultAddress: the address of the vault we are working on
+** - asyncActivationMap: the async ptr to the map of vaultAddress -> blockNumber
+** - wg: the async ptr to the WaitGroup to sync the goroutines
+**
+** Returns nothing as the asyncActivationMap is updated via a pointer
+**************************************************************************************************/
+func filterUpdateManagementOneTime(
+	chainID uint64,
+	vaultAddress common.Address,
+	asyncActivationMap *sync.Map,
+	wg *sync.WaitGroup,
+) {
+	defer wg.Done()
+	client := ethereum.RPC[chainID]
+
+	currentVault, err := contracts.NewYvault043(vaultAddress, client)
+	if err != nil {
+		logs.Error(err)
+		return
+	}
+	if log, err := currentVault.FilterUpdateManagement(&bind.FilterOpts{}); err == nil {
+		if log.Next() {
+			if log.Error() != nil {
+				logs.Error(log.Error())
+				asyncActivationMap.Store(vaultAddress, 0)
+				return
+			}
+			asyncActivationMap.Store(vaultAddress, log.Event.Raw.BlockNumber)
+		}
+	}
+}
+
+/**********************************************************************************************
+** The Activation method for the vaults is missleading on a blockchain perspective. It's not
+** the blockNumber of the vault creation, but the timestamp of the vault creation.
+** In order to get the logs from the vault initialization, we need to get the "Start" block
+** number.
+** To get it, we are querying one of the first event of the vault, which is an
+** "UpdateManagement". Then, we just append the value to our vaultsList structure.
+**********************************************************************************************/
+func RetrieveActivationForAllVaults(
+	chainID uint64,
+	vaults map[common.Address]utils.TVaultsFromRegistry,
+) map[common.Address]utils.TVaultsFromRegistry {
+	timeBefore := time.Now()
+
+	/**********************************************************************************************
+	** Concurrently retrieve all first updateManagement events, waiting for the end of all
+	** goroutines via the wg before continuing.
+	**********************************************************************************************/
+	asyncActivationMap := sync.Map{}
+	wg := &sync.WaitGroup{}
+	for _, v := range vaults {
+		wg.Add(1)
+		go filterUpdateManagementOneTime(chainID, v.VaultsAddress, &asyncActivationMap, wg)
+	}
+	wg.Wait()
+
+	/**********************************************************************************************
+	** Once we got all the activation blocks, we need to extract them from the sync.Map.
+	**
+	** The syncMap variable is setup as follows:
+	** - key: vaultAddress
+	** - value: blockNumber
+	**
+	** We need to update, for each corresponding vault, the activation block to the Activation
+	** key.
+	**********************************************************************************************/
+	count := 0
+	vaultListWithActivation := make(map[common.Address]utils.TVaultsFromRegistry)
+	asyncActivationMap.Range(func(key, value interface{}) bool {
+		if currentVault, ok := vaults[key.(common.Address)]; ok {
+			currentVault.Activation = value.(uint64)
+			vaultListWithActivation[key.(common.Address)] = currentVault
+			count++
+		}
+		return true
+	})
+
+	logs.Success(`It took`, time.Since(timeBefore), `to retrieve`, count, `activation events`)
+	return vaultListWithActivation
+}

--- a/internal/vaults/harvest.go
+++ b/internal/vaults/harvest.go
@@ -1,0 +1,174 @@
+package vaults
+
+import (
+	"sync"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/yearn/ydaemon/common/bigNumber"
+	"github.com/yearn/ydaemon/common/contracts"
+	"github.com/yearn/ydaemon/common/ethereum"
+	"github.com/yearn/ydaemon/internal/utils"
+)
+
+type THarvestFees struct {
+	ManagementFeeBPS       *bigNumber.Int
+	PerformanceFeeBPS      *bigNumber.Int
+	StrategistFeeBPS       *bigNumber.Int
+	TreasuryCollectedFee   *bigNumber.Int
+	StrategistCollectedFee *bigNumber.Int
+	TotalCollectedFee      *bigNumber.Int
+	TreasuryFeeRatio       *bigNumber.Float
+	StrategistFeeRatio     *bigNumber.Float
+	TotalFeeRatio          *bigNumber.Float
+}
+type THarvest struct {
+	// Extracted from common types.Log
+	TxHash      common.Hash
+	BlockHash   common.Hash
+	BlockNumber uint64
+	Timestamp   uint64
+	TxIndex     uint
+	LogIndex    uint
+	Removed     bool
+
+	// Extracted from Yvault043StrategyReported & computed
+	Vault        common.Address
+	Strategy     common.Address
+	VaultVersion string
+	Gain         *bigNumber.Int
+	Loss         *bigNumber.Int
+	TotalGain    *bigNumber.Int
+	TotalLoss    *bigNumber.Int
+	TotalDebt    *bigNumber.Int
+	DebtLimit    *bigNumber.Int // Only V0.2.2
+	DebtPaid     *bigNumber.Int // Only >= 0.3.1
+	DebtAdded    *bigNumber.Int
+	DebtRatio    *bigNumber.Int
+
+	// Computed
+	Duration *bigNumber.Int
+	Fees     THarvestFees
+}
+
+func (harvest *THarvest) New(log types.Log) *THarvest {
+	harvest.TxHash = log.TxHash
+	harvest.BlockHash = log.BlockHash
+	harvest.BlockNumber = log.BlockNumber
+	harvest.TxIndex = log.TxIndex
+	harvest.LogIndex = log.Index
+	harvest.Removed = log.Removed
+	return harvest
+}
+
+func findRelatedTransfers(
+	log *contracts.Yvault043StrategyReportedIterator,
+	transfersFromVaultsToStrategies map[common.Address]map[uint64][]utils.TEventBlock,
+	transfersFromVaultsToTreasury map[uint64][]utils.TEventBlock,
+) (*bigNumber.Int, *bigNumber.Int) {
+	currentBlock := utils.TEventBlock{
+		BlockNumber: log.Event.Raw.BlockNumber,
+		TxIndex:     log.Event.Raw.TxIndex,
+		LogIndex:    log.Event.Raw.Index,
+	}
+
+	transferToStrategist := utils.FindEventBefore(
+		map[uint64][]utils.TEventBlock{
+			currentBlock.BlockNumber: transfersFromVaultsToStrategies[log.Event.Strategy][currentBlock.BlockNumber],
+		},
+		currentBlock,
+	)
+	transferToTreasury := utils.FindEventBefore(
+		map[uint64][]utils.TEventBlock{
+			currentBlock.BlockNumber: transfersFromVaultsToTreasury[currentBlock.BlockNumber],
+		},
+		currentBlock,
+	)
+
+	return transferToStrategist, transferToTreasury
+}
+
+func durationSinceLastReport(
+	log *contracts.Yvault043StrategyReportedIterator,
+	allLastReport map[common.Address]map[uint64]uint64,
+) *bigNumber.Int {
+	previousBlockTimestampUint64 := utils.FindPreviousBlock(allLastReport[log.Event.Strategy], log.Event.Raw.BlockNumber)
+	duration := bigNumber.NewInt(0).Sub(
+		bigNumber.NewUint64(allLastReport[log.Event.Strategy][log.Event.Raw.BlockNumber]),
+		bigNumber.NewUint64(previousBlockTimestampUint64),
+	)
+	if previousBlockTimestampUint64 == 0 || duration.IsZero() {
+		return bigNumber.NewInt(0)
+	}
+	return duration
+}
+
+func HandleEvenStrategyReportedFor031To043(
+	chainID uint64,
+	vault utils.TVaultsFromRegistry,
+	managementFeeChanges map[uint64][]utils.TEventBlock,
+	performanceFeeChanges map[uint64][]utils.TEventBlock,
+	strategiesPerformanceFeeChanges map[common.Address]map[uint64][]utils.TEventBlock,
+	transfersFromVaultsToStrategies map[common.Address]map[uint64][]utils.TEventBlock,
+	transfersFromVaultsToTreasury map[uint64][]utils.TEventBlock,
+	allLastReport map[common.Address]map[uint64]uint64,
+	syncGroup *sync.WaitGroup,
+	harvests *[]THarvest,
+) {
+	defer syncGroup.Done()
+
+	client := ethereum.RPC[1]
+	currentVault, _ := contracts.NewYvault043(vault.VaultsAddress, client)
+	if log, err := currentVault.FilterStrategyReported(&bind.FilterOpts{Start: vault.Activation}, nil); err == nil {
+		for log.Next() {
+			if log.Error() != nil {
+				continue
+			}
+
+			currentBlock := utils.TEventBlock{
+				BlockNumber: log.Event.Raw.BlockNumber,
+				TxIndex:     log.Event.Raw.TxIndex,
+				LogIndex:    log.Event.Raw.Index,
+			}
+			transferToStrategist, transferToTreasury := findRelatedTransfers(log, transfersFromVaultsToStrategies, transfersFromVaultsToTreasury)
+
+			harvest := &THarvest{}
+			harvest.New(log.Event.Raw)
+			harvest.Timestamp = ethereum.GetBlockTime(chainID, log.Event.Raw.BlockNumber)
+			harvest.Vault = vault.VaultsAddress
+			harvest.VaultVersion = vault.APIVersion
+			harvest.Strategy = log.Event.Strategy
+			harvest.Gain = bigNumber.SetInt(log.Event.Gain)
+			harvest.Loss = bigNumber.SetInt(log.Event.Loss)
+			harvest.TotalGain = bigNumber.SetInt(log.Event.TotalGain)
+			harvest.TotalLoss = bigNumber.SetInt(log.Event.TotalLoss)
+			harvest.TotalDebt = bigNumber.SetInt(log.Event.TotalDebt)
+			harvest.DebtPaid = bigNumber.SetInt(log.Event.DebtPaid)
+			harvest.DebtAdded = bigNumber.SetInt(log.Event.DebtAdded)
+			harvest.DebtRatio = bigNumber.SetInt(log.Event.DebtRatio)
+			harvest.Duration = durationSinceLastReport(log, allLastReport)
+
+			harvest.Fees.ManagementFeeBPS = utils.FindEventBefore(managementFeeChanges, currentBlock)
+			harvest.Fees.PerformanceFeeBPS = utils.FindEventBefore(performanceFeeChanges, currentBlock)
+			harvest.Fees.StrategistFeeBPS = utils.FindEventBefore(strategiesPerformanceFeeChanges[log.Event.Strategy], currentBlock)
+			harvest.Fees.TreasuryCollectedFee = transferToTreasury
+			harvest.Fees.StrategistCollectedFee = transferToStrategist
+			harvest.Fees.TotalCollectedFee = bigNumber.NewInt(0).Add(transferToTreasury, transferToStrategist)
+			harvest.Fees.TreasuryFeeRatio = bigNumber.NewFloat(0).Div(
+				bigNumber.NewFloat(0).SetInt(harvest.Fees.TreasuryCollectedFee),
+				bigNumber.NewFloat(0).SetInt(harvest.Gain),
+			)
+			harvest.Fees.StrategistFeeRatio = bigNumber.NewFloat(0).Div(
+				bigNumber.NewFloat(0).SetInt(harvest.Fees.StrategistCollectedFee),
+				bigNumber.NewFloat(0).SetInt(harvest.Gain),
+			)
+			harvest.Fees.TotalFeeRatio = bigNumber.NewFloat(0).Div(
+				bigNumber.NewFloat(0).SetInt(harvest.Fees.TotalCollectedFee),
+				bigNumber.NewFloat(0).SetInt(harvest.Gain),
+			)
+
+			*harvests = append(*harvests, *harvest)
+		}
+	}
+}


### PR DESCRIPTION
- [X] Add the `internal` (could have been `core`) package to hold all the "logical" part of the program
- [X] Add the `registries` which can be used to retrieve all vaults ever registered by Yearn's systems via the `NewVault` and `NewExperimentalVault` events
- [X] Check enabled only on mainnet
- [X] Check enabled for registry V1 & V2