### PR TITLE
feat(risk): add stETH accumulator v2, maker v3, and FUD Aura Auto Staker

### DIFF
--- a/data/risks/networks/1/fudauraautostaker.json
+++ b/data/risks/networks/1/fudauraautostaker.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "risks",
+    "label": "FUD Aura Auto Staker",
+    "codeReviewScore": 4,
+    "testingScore": 4,
+    "auditScore": 4,
+    "protocolSafetyScore": 3,
+    "complexityScore": 2,
+    "teamKnowledgeScore": 4,
+    "criteria": {
+        "nameLike": [
+            "FUDAuraAutoStaker"
+        ],
+        "strategies": [],
+        "exclude": []
+    }
+}

--- a/data/risks/networks/1/inactive.json
+++ b/data/risks/networks/1/inactive.json
@@ -130,7 +130,10 @@
 			"strategygoldfinch",
 			"auto-compounding aura",
 			"maker-lev",
-			"convextempledao-u"
+			"convextempledao-u",
+			"StrategystETHAccumulator_v2",
+			"makerv3",
+			"FUDAuraAutoStaker"
 		]
 	}
 }

--- a/data/risks/networks/1/maker.json
+++ b/data/risks/networks/1/maker.json
@@ -14,7 +14,8 @@
 		"strategies": [],
 		"exclude": [
 			"makerv2",
-			"maker-lev"
+			"maker-lev",
+			"makerv3"
 		]
 	}
 }

--- a/data/risks/networks/1/makerv3.json
+++ b/data/risks/networks/1/makerv3.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "risks",
+    "label": "Maker V3",
+    "codeReviewScore": 3,
+    "testingScore": 2,
+    "auditScore": 5,
+    "protocolSafetyScore": 1,
+    "complexityScore": 4,
+    "teamKnowledgeScore": 2,
+    "criteria": {
+        "nameLike": [
+            "makerv3"
+        ],
+        "strategies": [],
+        "exclude": []
+    }
+}

--- a/data/risks/networks/1/strategystethaccumulator_v2.json
+++ b/data/risks/networks/1/strategystethaccumulator_v2.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "risks",
-	"label": "stETH Accumulator",
-	"codeReviewScore": 1,
+	"label": "stETH accumulator v2",
+	"codeReviewScore": 3,
 	"testingScore": 3,
 	"auditScore": 5,
 	"protocolSafetyScore": 2,
@@ -9,11 +9,11 @@
 	"teamKnowledgeScore": 2,
 	"criteria": {
 		"nameLike": [
-			"accumulator"
+			"StrategystETHAccumulator_v2"
 		],
 		"strategies": [],
 		"exclude": [
-			"StrategystETHAccumulator_v2"
+			"StrategystETHAccumulator"
 		]
 	}
 }


### PR DESCRIPTION
closes https://github.com/yearn/ydata/issues/109, #103, #107, #109 

added the handles for the newer versions in the exclude criteria of the older versions.
also added the handles to the exclude criteria of the Inactive group.

and for the Maker V3 group,
I assumed that the risk group is for the Mainnet.