### PR TITLE
fix(risk): check whether nameLike includes exclude criteria

### DIFF
--- a/internal/strategies/daemon.strategies.risk.go
+++ b/internal/strategies/daemon.strategies.risk.go
@@ -20,6 +20,14 @@ import (
 func excludeNameLike(strat models.TStrategyList, group TStrategyGroupFromRisk) bool {
 	if len(group.Criteria.Exclude) > 0 {
 		for _, stratExclude := range group.Criteria.Exclude {
+			// temporary fix to handle substring inclusion
+			if len(group.Criteria.NameLike) > 0 {
+				for _, nameLike := range group.Criteria.NameLike {
+					if strings.Contains(strings.ToLower(nameLike), strings.ToLower(stratExclude)) && includeNameLike(strat, group) {
+						return false
+					}
+				}
+			}
 			if strings.Contains(strings.ToLower(strat.Name), strings.ToLower(stratExclude)) {
 				return true
 			}


### PR DESCRIPTION
Temporary fix to give the proper score to the StrategystETHAccumulator_v2 strategy (0x120FA5738751b275aed7F7b46B98beB38679e093) for the upcoming document.

There was a problem with parsing the risk group when the nameLike includes the whole string of the exclude criterion,
thus have added an additional check for this case.