### PR TITLE
fix(risk): add longevity to the calculation of group risk scores

### DIFF
--- a/internal/strategies/model.risk.go
+++ b/internal/strategies/model.risk.go
@@ -28,6 +28,7 @@ type TStrategyGroupFromRisk struct {
 	ProtocolSafetyScore int                     `json:"protocolSafetyScore"`
 	TeamKnowledgeScore  int                     `json:"teamKnowledgeScore"`
 	TestingScore        int                     `json:"testingScore"`
+	LongevityImpact     int                     `json:"longevityImpact"`
 	ChainID             uint64                  `json:"chainID"`
 	Criteria            TStrategyGroupCritieria `json:"criteria"`
 	Allocation          *TStrategyAllocation    `json:"allocation"`


### PR DESCRIPTION
fixes #165 
now it does another loop before calculating the median allocation, which collects the longevity scores of each strategy.