### PR TITLE
fix: increase the thresholds for the yellow zone

### DIFF
--- a/common/bigNumber/float.go
+++ b/common/bigNumber/float.go
@@ -57,6 +57,14 @@ func (b *Float) SetUint64(s uint64) *Float {
 	b.Float.SetUint64(s)
 	return b
 }
+func (b *Float) SetInf(sign ...bool) *Float {
+	if len(sign) == 0 {
+		b.Float.SetInf(false)
+		return b
+	}
+	b.Float.SetInf(sign[0])
+	return b
+}
 func (b *Float) Add(x *Float, y *Float) *Float {
 	xAsFloat := ToFloat(x)
 	yAsFloat := ToFloat(y)

--- a/internal/strategies/risk.framework.go
+++ b/internal/strategies/risk.framework.go
@@ -98,15 +98,15 @@ func getAllocationStatus(group TStrategyGroupFromRisk) string {
 	diffAllowed := bigNumber.NewFloat(0)
 	switch {
 	case median <= 1:
-		diffAllowed = bigNumber.NewFloat(100_000_000)
+		diffAllowed = diffAllowed.SetInf()
 	case median <= 2:
-		diffAllowed = bigNumber.NewFloat(50_000_000)
+		diffAllowed = diffAllowed.SetInf()
 	case median <= 3:
-		diffAllowed = bigNumber.NewFloat(40_000_000)
+		diffAllowed = bigNumber.NewFloat(90_000_000)
 	case median <= 4:
-		diffAllowed = bigNumber.NewFloat(9_000_000)
+		diffAllowed = bigNumber.NewFloat(49_000_000)
 	case median <= 5:
-		diffAllowed = bigNumber.NewFloat(1_000_000)
+		diffAllowed = bigNumber.NewFloat(10_000_000)
 	}
 	// over allocated but within allowed range - Yellow
 	if diff.Sub(diffAllowed, diff).Sign() > 0 {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/30872891/205761884-9f4175ed-b88d-4ca7-a7a7-4e6f27c5f5e0.png)
from https://yearn.watch/risk

the yellow zone actually should span for 2 blocks, whereas the current implementation spans for only a single block.
The thresholds have been modified to remove this difference.