### PR TITLE
fix: set the default ABI version for the getStrategies call as 0.4.3

### DIFF
--- a/internal/strategies/multicallMethods.go
+++ b/internal/strategies/multicallMethods.go
@@ -43,7 +43,7 @@ func getDebtOutstanding(name string, contractAddress common.Address, strategyAdd
 }
 
 func getStrategies(name string, contractAddress common.Address, strategyAddress common.Address, version string) ethereum.Call {
-	abiToUse := YearnVaultABI
+	var abiToUse *abi.ABI
 
 	switch version {
 	case `0.2.2`:
@@ -53,11 +53,11 @@ func getStrategies(name string, contractAddress common.Address, strategyAddress 
 		_abi, _ := abi.JSON(strings.NewReader(helpers.YEARN_VAULT_V030_ABI))
 		abiToUse = &_abi
 	default:
-		_abi, _ := abi.JSON(strings.NewReader(helpers.YEARN_VAULT_V030_ABI))
-		abiToUse = &_abi
+		abiToUse = YearnVaultABI
 	}
 
 	parsedData, _ := abiToUse.Pack("strategies", strategyAddress.Address)
+
 	return ethereum.Call{
 		Name:     name,
 		Target:   contractAddress.Address,


### PR DESCRIPTION
fix the default ABI version for the `getStrategies` call as 0.4.3,
which has been changed to 0.3.0 from the commit 02a3cf3258d1c1b1ed9dc2605a5fa1885b67df09
