### PR TITLE
feat: add DeFiLlama and CoinGecko APIs in prices

### DIFF
--- a/common/env/constants.go
+++ b/common/env/constants.go
@@ -141,3 +141,21 @@ var CURVE_REGISTRY_ADDRESSES = map[uint64]common.Address{
 	250:   common.HexToAddress(`0x0000000022d53366457f9d5e68ec105046fc4383`),
 	42161: common.HexToAddress(`0x0000000022d53366457f9d5e68ec105046fc4383`),
 }
+
+// LLAMA_PRICE_URL contains the URL for the DeFiLlama pricing API
+var LLAMA_CHAIN_NAMES = map[uint64]string{
+	1:     `ethereum`,
+	10:    `optimism`,
+	250:   `fantom`,
+	42161: `arbitrum`,
+}
+var LLAMA_PRICE_URL = `https://coins.llama.fi/prices/current/`
+
+// GECKO_PRICE_URL contains the URL for the CoinGecko API
+var GECKO_CHAIN_NAMES = map[uint64]string{
+	1:     `ethereum`,
+	10:    `optimistic-ethereum`,
+	250:   `fantom`,
+	42161: `arbitrum-one`,
+}
+var GECKO_PRICE_URL = `https://api.coingecko.com/api/v3/coins/`

--- a/internal/prices/model.go
+++ b/internal/prices/model.go
@@ -29,6 +29,27 @@ type TCurveFactories struct {
 	} `json:"data"`
 }
 
+type TLlamaPriceData struct {
+	Decimals int     `json:"decimals"`
+	Price    float64 `json:"price"`
+	Symbol   string  `json:"symbol"`
+}
+
+type TLlamaPrice struct {
+	Coins map[string]TLlamaPriceData `json:"coins"`
+}
+
+type TGeckoPrice struct {
+	TokenId    string `json:"id"`
+	Symbol     string `json:"symbol"`
+	Name       string `json:"name"`
+	MarketData struct {
+		CurrentPrice struct {
+			USDPrice float64 `json:"usd"`
+		} `json:"current_price"`
+	} `json:"market_data"`
+}
+
 /**********************************************************************************************
 ** Set of functions to store and retrieve the prices from the cache and/or database and being
 ** able to access them from the rest of the application.


### PR DESCRIPTION
resolves #156 and #157 

Added the DeFiLlama coin pricing API and the CoinGecko API in `internal/prices/fetcher.go`.
First tries to fetch the price from DeFiLlama, then tries to fetch the price from CoinGecko,
and converts the float64 prices into int assuming they will be handled as USDC prices with decimals of 6.