### PR TITLE
feat(risk): update testing score of stargate strategies

### DIFF
--- a/data/risks/networks/1/stargate.json
+++ b/data/risks/networks/1/stargate.json
@@ -2,7 +2,7 @@
 	"$schema": "risks",
 	"label": "Stargate",
 	"codeReviewScore": 2,
-	"testingScore": 4,
+	"testingScore": 3,
 	"auditScore": 5,
 	"protocolSafetyScore": 4,
 	"complexityScore": 4,

--- a/data/risks/networks/250/stargate.json
+++ b/data/risks/networks/250/stargate.json
@@ -2,7 +2,7 @@
 	"$schema": "risks",
 	"label": "Stargate",
 	"codeReviewScore": 2,
-	"testingScore": 4,
+	"testingScore": 3,
 	"auditScore": 5,
 	"protocolSafetyScore": 4,
 	"complexityScore": 4,

--- a/data/risks/networks/42161/stargate.json
+++ b/data/risks/networks/42161/stargate.json
@@ -2,7 +2,7 @@
 	"$schema": "risks",
 	"label": "Stargate",
 	"codeReviewScore": 3,
-	"testingScore": 4,
+	"testingScore": 3,
 	"auditScore": 5,
 	"protocolSafetyScore": 4,
 	"complexityScore": 4,


### PR DESCRIPTION
resolves #176 
the maximum allowed TVL for the Stargate group should be increased to 10M by this PR, by changing the median score from 4 -> 3.