### PR TITLE
feat: add strategy routes

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -109,6 +109,11 @@ func NewRouter() *gin.Engine {
 		GET(router, `:chainID/vaults/apy/:address`, c.GetVaultsVisionAPY)
 		GET(router, `:chainID/earned/:address/:vaults`, c.GetEarnedPerVaultPerUser)
 		GET(router, `:chainID/earned/:address`, c.GetEarnedPerUser)
+
+		// Retrieve the strategies for a specific chainID
+		GET(router, `:chainID/strategies/all`, c.GetAllStrategies)
+		GET(router, `:chainID/strategies/:address`, c.GetStrategy)
+		GET(router, `:chainID/strategy/:address`, c.GetStrategy)
 	}
 
 	// Strategies section

--- a/external/vaults/route.strategies.all.go
+++ b/external/vaults/route.strategies.all.go
@@ -1,0 +1,82 @@
+package vaults
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/yearn/ydaemon/common/env"
+	"github.com/yearn/ydaemon/common/helpers"
+	"github.com/yearn/ydaemon/common/sort"
+	"github.com/yearn/ydaemon/common/types/common"
+	"github.com/yearn/ydaemon/internal/strategies"
+	"github.com/yearn/ydaemon/internal/vaults"
+)
+
+// GetAllStrategies will, for a given chainID, return a list of all strategies
+func (y Controller) GetAllStrategies(c *gin.Context) {
+	hideAlways := helpers.StringToBool(helpers.SafeString(c.Query(`hideAlways`), `false`))
+	orderBy := helpers.SafeString(c.Query(`orderBy`), `details.order`)
+	orderDirection := helpers.SafeString(c.Query(`orderDirection`), `asc`)
+	strategiesCondition := selectStrategiesCondition(c.Query(`strategiesCondition`))
+	withStrategiesDetails := c.Query(`strategiesDetails`) == `withDetails`
+	migrable := selectMigrableCondition(c.Query(`migrable`))
+	chainID, ok := helpers.AssertChainID(c.Param(`chainID`))
+	if !ok {
+		c.String(http.StatusBadRequest, `invalid chainID`)
+		return
+	}
+	if migrable != `none` && hideAlways {
+		c.String(http.StatusBadRequest, `migrable and hideAlways cannot be true at the same time`)
+		return
+	}
+
+	data := []TStrategy{}
+	allVaults := vaults.ListVaults(chainID)
+	for _, currentVault := range allVaults {
+		vaultAddress := common.FromAddress(currentVault.Address)
+		if helpers.Contains(env.BLACKLISTED_VAULTS[chainID], vaultAddress) {
+			continue
+		}
+
+		newVault := NewVault().AssignTVault(currentVault)
+		if migrable == `none` && (newVault.Details.HideAlways || newVault.Details.Retired) && hideAlways {
+			continue
+		} else if migrable == `nodust` && (newVault.TVL.TVL < 100 || !newVault.Migration.Available) {
+			continue
+		} else if migrable == `all` && !newVault.Migration.Available {
+			continue
+		}
+
+		vaultStrategies := strategies.ListStrategiesForVault(chainID, vaultAddress)
+		for _, strategy := range vaultStrategies {
+			var externalStrategy *TStrategy
+			strategyWithDetails := NewStrategy().AssignTStrategy(strategy)
+			if !strategyWithDetails.ShouldBeIncluded(strategiesCondition) {
+				continue
+			}
+
+			if withStrategiesDetails {
+				externalStrategy = strategyWithDetails
+				externalStrategy.Risk = NewRiskScore().AssignTStrategyFromRisk(strategy.BuildRiskScore())
+			} else {
+				externalStrategy = &TStrategy{
+					Address:     common.FromAddress(strategy.Address),
+					Name:        strategy.Name,
+					Description: strategy.Description,
+				}
+			}
+			// Directly append the strategy
+			data = append(data, *externalStrategy)
+		}
+	}
+
+	// Preparing the sort. This specifics steps are needed to avoid a panic
+	var sortedData = make([]interface{}, len(data))
+	for i, d := range data {
+		sortedData[i] = d
+	}
+	sort.SortBy(sortedData, orderBy, orderDirection) //Sort by details.order by default
+
+	c.JSON(http.StatusOK, sortedData)
+
+}

--- a/external/vaults/route.strategies.one.go
+++ b/external/vaults/route.strategies.one.go
@@ -1,0 +1,43 @@
+package vaults
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/yearn/ydaemon/common/helpers"
+	"github.com/yearn/ydaemon/common/types/common"
+	"github.com/yearn/ydaemon/internal/strategies"
+)
+
+// GetVault will, for a given chainID, return a list of all vaults
+func (y Controller) GetStrategy(c *gin.Context) {
+	chainID, ok := helpers.AssertChainID(c.Param("chainID"))
+	if !ok {
+		c.String(http.StatusBadRequest, "invalid chainID")
+		return
+	}
+	address, ok := helpers.AssertAddress(c.Param("address"), chainID)
+	if !ok {
+		c.String(http.StatusBadRequest, "invalid address")
+		return
+	}
+
+	withStrategiesDetails := c.Query("strategiesDetails") == "withDetails"
+	strategy, ok := strategies.FindStrategy(chainID, address.ToAddress())
+	if !ok {
+		c.String(http.StatusBadRequest, "invalid strategy")
+		return
+	}
+	var newStrategy *TStrategy
+	if withStrategiesDetails {
+		newStrategy = NewStrategy().AssignTStrategy(strategy)
+		newStrategy.Risk = NewRiskScore().AssignTStrategyFromRisk(strategy.BuildRiskScore())
+	} else {
+		newStrategy = &TStrategy{
+			Address:     common.FromAddress(strategy.Address),
+			Name:        strategy.Name,
+			Description: strategy.Description,
+		}
+	}
+	c.JSON(http.StatusOK, *newStrategy)
+}


### PR DESCRIPTION
Aims to add 3 basic routes for querying strategies directly.
* :chainID/strategies/all
* :chainID/strategies/:address
* :chainID/strategy/:address

I have copied the query params from the vault queries