### PR TITLE
feat(risk): add compound v3 lender borrower group

### DIFF
--- a/data/risks/networks/1/aave-lender-borrower.json
+++ b/data/risks/networks/1/aave-lender-borrower.json
@@ -15,7 +15,8 @@
 		"strategies": [],
 		"exclude": [
 			"Levered-AAVE-wBTC",
-			"88MPH"
+			"88MPH",
+			"CompV3"
 		]
 	}
 }

--- a/data/risks/networks/1/compound-v3-lender-borrower.json
+++ b/data/risks/networks/1/compound-v3-lender-borrower.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "risks",
+    "label": "Compound V3 Lender Borrower",
+    "codeReviewScore": 3,
+    "testingScore": 3,
+    "auditScore": 4,
+    "protocolSafetyScore": 2,
+    "complexityScore": 4,
+    "teamKnowledgeScore": 3,
+    "criteria": {
+        "nameLike": [
+            "CompV3",
+            "Lender",
+            "Borrower"
+        ],
+        "strategies": ["0x9E9a2a86eeff52FFD13fc724801a4259b2B1A949"],
+        "exclude": [
+            "aave"
+        ]
+    }
+}


### PR DESCRIPTION
resolves #216 

adds new file for the compound v3 lender borrower group in mainnet,
and also adds the exclusion for the aave lender borrower group to prevent mismatches