### PR TITLE
fix: remove nameLikes from compv3 lender borrower

### DIFF
--- a/data/risks/networks/1/compound-v3-lender-borrower.json
+++ b/data/risks/networks/1/compound-v3-lender-borrower.json
@@ -8,14 +8,8 @@
     "complexityScore": 4,
     "teamKnowledgeScore": 3,
     "criteria": {
-        "nameLike": [
-            "CompV3",
-            "Lender",
-            "Borrower"
-        ],
+        "nameLike": [],
         "strategies": ["0x9E9a2a86eeff52FFD13fc724801a4259b2B1A949"],
-        "exclude": [
-            "aave"
-        ]
+        "exclude": []
     }
 }


### PR DESCRIPTION
Now only the strategy `0x9E9a2a86eeff52FFD13fc724801a4259b2B1A949` is classified as the Compound V3 Lender Borrower group.