### PR TITLE
feat: Add partner tracker address for base network

### DIFF
--- a/common/env/constants.go
+++ b/common/env/constants.go
@@ -289,7 +289,8 @@ var PARTNER_TRACKERS_ADDRESSES = map[uint64]TContractData{
 		Block:   uint64(40499061),
 	},
 	8453: {
-		//TODO: ADD PARTNER_TRACKERS_ADDRESSES FOR BASE
+		Address: common.HexToAddress(`0xd0f08e42a40569ff83d28aa783a5b6537462667c`),
+		Block:   uint64(3350506),
 	},
 	42161: {
 		Address: common.HexToAddress(`0x0e5b46E4b2a05fd53F5a4cD974eb98a9a613bcb7`),


### PR DESCRIPTION
Add partner tracker details for Base network. 

Partner Tracker contact: https://basescan.org/address/0xd0f08e42a40569ff83d28aa783a5b6537462667c

Contract creation transaction: https://basescan.org/tx/0xf0ef943c4c1396e2cc982d55dd9802902ff913abf0d9c5a01cda009c94121991