### PR TITLE
chore: hide bal vault as yBal pending

### DIFF
--- a/data/meta/vaults/1/0x1bb04fCBC210bAA384531079ed7f59d9149309ba.json
+++ b/data/meta/vaults/1/0x1bb04fCBC210bAA384531079ed7f59d9149309ba.json
@@ -1,7 +1,7 @@
 {
   "$schema": "vault",
   "comment": "Balancer DAI-USDC-USDT-f",
-  "hideAlways": false,
+  "hideAlways": true,
   "depositsDisabled": false,
   "withdrawalsDisabled": false,
   "order": 350,

--- a/data/meta/vaults/1/0x20F6A2ec303dF7120eAe3346dE5aD877f80Beb64.json
+++ b/data/meta/vaults/1/0x20F6A2ec303dF7120eAe3346dE5aD877f80Beb64.json
@@ -1,7 +1,7 @@
 {
   "$schema": "vault",
   "comment": "Balancer AuraBAL-f",
-  "hideAlways": false,
+  "hideAlways": true,
   "depositsDisabled": false,
   "withdrawalsDisabled": false,
   "order": 341,

--- a/data/meta/vaults/1/0x4cb5483D87028518c5F35a49c151612a062bfCD0.json
+++ b/data/meta/vaults/1/0x4cb5483D87028518c5F35a49c151612a062bfCD0.json
@@ -1,7 +1,7 @@
 {
   "$schema": "vault",
   "comment": "Balancer GHO-bb-a-USD-f",
-  "hideAlways": false,
+  "hideAlways": true,
   "depositsDisabled": false,
   "withdrawalsDisabled": false,
   "order": 402,

--- a/data/meta/vaults/1/0x883A777f2594004419fc08b388D7d3bdC1c0D6c1.json
+++ b/data/meta/vaults/1/0x883A777f2594004419fc08b388D7d3bdC1c0D6c1.json
@@ -1,7 +1,7 @@
 {
   "$schema": "vault",
   "comment": "Balancer bba-USD-v3-f",
-  "hideAlways": false,
+  "hideAlways": true,
   "depositsDisabled": false,
   "withdrawalsDisabled": false,
   "order": 345,

--- a/data/meta/vaults/1/0x9894acf19de6F00D4056DbFDDF2dd7444F993D87.json
+++ b/data/meta/vaults/1/0x9894acf19de6F00D4056DbFDDF2dd7444F993D87.json
@@ -1,7 +1,7 @@
 {
   "$schema": "vault",
   "comment": "Balancer wstETH-rETH-sfrxETH-f",
-  "hideAlways": false,
+  "hideAlways": true,
   "depositsDisabled": false,
   "withdrawalsDisabled": false,
   "order": 338,

--- a/data/meta/vaults/1/0xAA4f7562D3C25Bd2fCB8FEd615182667C0A7086C.json
+++ b/data/meta/vaults/1/0xAA4f7562D3C25Bd2fCB8FEd615182667C0A7086C.json
@@ -1,7 +1,7 @@
 {
   "$schema": "vault",
   "comment": "Balancer StaFi rETH-wETH-f",
-  "hideAlways": false,
+  "hideAlways": true,
   "depositsDisabled": false,
   "withdrawalsDisabled": false,
   "order": 333,

--- a/data/meta/vaults/1/0xC8BE5E2aE51c3F75FcfBD900505Ec63Ce7dE320c.json
+++ b/data/meta/vaults/1/0xC8BE5E2aE51c3F75FcfBD900505Ec63Ce7dE320c.json
@@ -1,7 +1,7 @@
 {
   "$schema": "vault",
   "comment": "balancer wstETH-wETH-f",
-  "hideAlways": false,
+  "hideAlways": true,
   "depositsDisabled": false,
   "withdrawalsDisabled": false,
   "order": 324,

--- a/data/meta/vaults/1/0xc325849908D482550b87f96ef60271B95f92C861.json
+++ b/data/meta/vaults/1/0xc325849908D482550b87f96ef60271B95f92C861.json
@@ -1,7 +1,7 @@
 {
   "$schema": "vault",
   "comment": "Balancer cbETH-wstETH-f",
-  "hideAlways": false,
+  "hideAlways": true,
   "depositsDisabled": false,
   "withdrawalsDisabled": false,
   "order": 346,

--- a/data/meta/vaults/1/0xcE71767158421482C39E72f209A7A8ef3A0c669d.json
+++ b/data/meta/vaults/1/0xcE71767158421482C39E72f209A7A8ef3A0c669d.json
@@ -1,7 +1,7 @@
 {
   "$schema": "vault",
   "comment": "Balancer rETH-wETH-f",
-  "hideAlways": false,
+  "hideAlways": true,
   "depositsDisabled": false,
   "withdrawalsDisabled": false,
   "order": 320,

--- a/data/meta/vaults/1/0xd6A528faAd34Fe51c6F181acF43C1E20db4f84aC.json
+++ b/data/meta/vaults/1/0xd6A528faAd34Fe51c6F181acF43C1E20db4f84aC.json
@@ -1,7 +1,7 @@
 {
   "$schema": "vault",
   "comment": "Balancer DOLA-USDC-f",
-  "hideAlways": false,
+  "hideAlways": true,
   "depositsDisabled": false,
   "withdrawalsDisabled": false,
   "order": 319,

--- a/data/meta/vaults/1/0xfb9A680825f29972629b2295E050f74CB2f4992b.json
+++ b/data/meta/vaults/1/0xfb9A680825f29972629b2295E050f74CB2f4992b.json
@@ -1,7 +1,7 @@
 {
   "$schema": "vault",
   "comment": "Balancer GHO-LUSD-f",
-  "hideAlways": false,
+  "hideAlways": true,
   "depositsDisabled": false,
   "withdrawalsDisabled": false,
   "order": 401,


### PR DESCRIPTION
Hide the following vaults until yBal is released:
```
0x9894acf19de6F00D4056DbFDDF2dd7444F993D87
0x883A777f2594004419fc08b388D7d3bdC1c0D6c1
0xd6A528faAd34Fe51c6F181acF43C1E20db4f84aC
0x4cb5483D87028518c5F35a49c151612a062bfCD0
0xcE71767158421482C39E72f209A7A8ef3A0c669d
0xc325849908D482550b87f96ef60271B95f92C861
0xfb9A680825f29972629b2295E050f74CB2f4992b
0xC8BE5E2aE51c3F75FcfBD900505Ec63Ce7dE320c
0xAA4f7562D3C25Bd2fCB8FEd615182667C0A7086C
0x1bb04fCBC210bAA384531079ed7f59d9149309ba
0x20F6A2ec303dF7120eAe3346dE5aD877f80Beb64
```