### PR TITLE
feat: compare summed and current

### DIFF
--- a/processes/apr/forward.v3.go
+++ b/processes/apr/forward.v3.go
@@ -62,9 +62,8 @@ func computeVaultV3ForwardAPR(
 	** Otherwise we can do the classic calculation of the net APR by summing the APR of each
 	** strategy weighted by the debt ratio of each strategy.
 	**********************************************************************************************/
-	shouldUseV2Method := false
-	if shouldUseV2Method && vault.Kind == models.VaultKindMultiple {
-		netAPR = bigNumber.NewFloat(0)
+	summedApr = bigNumber.NewFloat(0)
+	if vault.Kind == models.VaultKindMultiple {
 		for _, strategy := range allStrategiesForVault {
 			if strategy.LastDebtRatio == nil || strategy.LastDebtRatio.IsZero() {
 				if os.Getenv("ENVIRONMENT") == "dev" {
@@ -82,8 +81,16 @@ func computeVaultV3ForwardAPR(
 			debtRatio := helpers.ToNormalizedAmount(strategy.LastDebtRatio, 4)
 			scaledStrategyAPR := bigNumber.NewFloat(0).Mul(humanizedAPR, debtRatio)
 			scaledStrategyAPR = bigNumber.NewFloat(0).Mul(scaledStrategyAPR, bigNumber.NewFloat(0.8))
-			netAPR = bigNumber.NewFloat(0).Add(netAPR, scaledStrategyAPR)
+			summedApr = bigNumber.NewFloat(0).Add(summedApr, scaledStrategyAPR)
 		}
+	}
+
+	/**********************************************************************************************
+	** The current APR from the oracle can be artifically low if we have recently received
+	*  new deposits. We can at least expect to get the summedApr so we take the higher of the two.
+	**********************************************************************************************/
+	if summedApr > netAPR {
+		netAPR := summedApr
 	}
 
 	return TForwardAPR{


### PR DESCRIPTION
- Use a comparision for multi strategy vaults between currentApr from the oracle and the v2 style summed APR from all its strategies.

- This means when large deposits push down the current apr a realistic version is still displayed