### PR TITLE
Fix spelling errors in documentation

### DIFF
--- a/common/helpers/README.md
+++ b/common/helpers/README.md
@@ -1,3 +1,3 @@
 # Utils
 In the `utils` package, we have all the functions that could not fit in a specific package.  
-We are storing them the Environment variable seteup, the constant we may need to use accross the program, some very specific utilities, etc.
+We are storing them the Environment variable setup, the constant we may need to use across the program, some very specific utilities, etc.

--- a/internal/models/README.md
+++ b/internal/models/README.md
@@ -1,4 +1,4 @@
 # Models
 The `models` package is kind of the same as the `types` folder in Typescript. It's a registry of all the types we may need accross our program, in a separate package so we could use them and call them no matter where we are.   
 No logic, or the smallest logic should be implemented in here.   
-It's moslty a `give me the struct please` package.
+It's mostly a `give me the struct please` package.


### PR DESCRIPTION
Fixed:

Corrected seteup to setup for proper spelling.
Changed accross to across for correct spelling.
Fixed moslty to mostly for proper spelling.
Why it's useful:
These changes address spelling errors, improving the accuracy and readability of the text.