### PR TITLE
fix: remove sky compounder, add usds-1 to featured

### DIFF
--- a/data/meta/vaults/1.json
+++ b/data/meta/vaults/1.json
@@ -3683,7 +3683,7 @@
 				"isAggregator": false,
 				"isBoosted": false,
 				"isAutomated": false,
-				"isHighlighted": false,
+				"isHighlighted": true,
 				"isPool": false,
 				"shouldUseV2APR": true,
 				"migration": {
@@ -13291,7 +13291,7 @@
 				"isAggregator": false,
 				"isBoosted": false,
 				"isAutomated": false,
-				"isHighlighted": true,
+				"isHighlighted": false,
 				"isPool": false,
 				"shouldUseV2APR": false,
 				"migration": {


### PR DESCRIPTION
The yvUSDS-1vault (0x182863131f9a4630ff9e27830d945b1413e347e8) was removed from "fancy", but should have been the SKY compounder vault (0x4ce9c93513dff543bc392870d57df8c04e89ba0a)

This PR removes the sky compounder vault and adds the USDS-1 vault

