### PR TITLE
feat: add katana flag and route

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -73,6 +73,7 @@ func NewRouter() *gin.Engine {
 		router.GET(`vaults/pooltogether`, CacheSimplifiedVaults(cachingStore, 5*time.Minute, c.GetIsYearnPoolTogether))
 		router.GET(`vaults/cove`, CacheSimplifiedVaults(cachingStore, 5*time.Minute, c.GetIsYearnCove))
 		router.GET(`vaults/morpho`, CacheSimplifiedVaults(cachingStore, 5*time.Minute, c.GetIsMorpho))
+		router.GET(`vaults/katana`, CacheSimplifiedVaults(cachingStore, 5*time.Minute, c.GetIsKatana))
 		router.GET(`vaults/ajna`, CacheSimplifiedVaults(cachingStore, 5*time.Minute, c.GetIsAjna))
 		router.GET(`vaults/velodrome`, CacheSimplifiedVaults(cachingStore, 5*time.Minute, c.GetIsVelodrome))
 		router.GET(`vaults/aerodrome`, CacheSimplifiedVaults(cachingStore, 5*time.Minute, c.GetIsAerodrome))

--- a/data/meta/vaults/1.json
+++ b/data/meta/vaults/1.json
@@ -12481,7 +12481,8 @@
 					"isPoolTogether": false,
 					"isCove": false,
 					"isMorpho": false,
-					"isPublicERC4626": false
+					"isPublicERC4626": false,
+					"isKatana": true
 				},
 				"riskLevel": 0,
 				"riskScore": {
@@ -22073,7 +22074,8 @@
 					"isPoolTogether": false,
 					"isCove": false,
 					"isMorpho": false,
-					"isPublicERC4626": false
+					"isPublicERC4626": false,
+					"isKatana": true
 				},
 				"riskLevel": 0,
 				"riskScore": {
@@ -26427,7 +26429,8 @@
 					"isPoolTogether": false,
 					"isCove": false,
 					"isMorpho": false,
-					"isPublicERC4626": false
+					"isPublicERC4626": false,
+					"isKatana": true
 				},
 				"riskLevel": 0,
 				"riskScore": {
@@ -37066,7 +37069,8 @@
 					"isPoolTogether": false,
 					"isCove": false,
 					"isMorpho": false,
-					"isPublicERC4626": false
+					"isPublicERC4626": false,
+					"isKatana": true
 				},
 				"riskLevel": 0,
 				"riskScore": {

--- a/docs/available-endpoints.md
+++ b/docs/available-endpoints.md
@@ -68,6 +68,10 @@ Returns all vaults matching the `inclusion.isCove` filter.
 
 Returns all vaults matching the `inclusion.isMorpho` filter.
 
+#### **GET** `/vaults/katana`
+
+Returns all vaults matching the `inclusion.isKatana` filter.
+
 #### **GET** `/vaults/ajna`
 
 Returns all vaults with the Ajna category and the `inclusion.IsYearn` filter.

--- a/external/vaults/route.vaults.go
+++ b/external/vaults/route.vaults.go
@@ -211,6 +211,16 @@ func (y Controller) GetIsMorpho(c *gin.Context) ([]TSimplifiedExternalVault, err
 }
 
 /**************************************************************************************************
+** GetIsKatana is a gin handler function to retrieve all the vaults matching the
+** inclusion.isKatana filter.
+**************************************************************************************************/
+func (y Controller) GetIsKatana(c *gin.Context) ([]TSimplifiedExternalVault, error) {
+	return getVaults(c, func(vault models.TVault) bool {
+		return vault.Metadata.Inclusion.IsKatana
+	})
+}
+
+/**************************************************************************************************
 ** GetIsAjna is a gin handler function to retrieve all the vaults with a name matching `AJNA` or
 ** with the inclusion.IsYearnJuiced filter.
 **************************************************************************************************/

--- a/external/vaults/route.vaults_test.go
+++ b/external/vaults/route.vaults_test.go
@@ -273,6 +273,7 @@ func TestCategoryFilters(t *testing.T) {
 		{"GetIsOptimism", controller.GetIsOptimism},
 		{"GetIsYearnPoolTogether", controller.GetIsYearnPoolTogether},
 		{"GetIsMorpho", controller.GetIsMorpho},
+		{"GetIsKatana", controller.GetIsKatana},
 	}
 
 	for _, test := range categoryTests {

--- a/internal/fetcher/vaults.go
+++ b/internal/fetcher/vaults.go
@@ -293,6 +293,7 @@ func RetrieveAllVaults(
 			vault.Metadata.Inclusion.IsPoolTogether = env.IsRegistryFromPoolTogether(chainID, vault.RegistryAddress)
 			vault.Metadata.Inclusion.IsCove = env.IsRegistryFromCove(chainID, vault.RegistryAddress)
 			vault.Metadata.Inclusion.IsMorpho = false //False by default
+			vault.Metadata.Inclusion.IsKatana = false //False by default
 			vault.Metadata.Inclusion.IsGimme = false  //False by default
 
 			isYearn := vault.Metadata.Inclusion.IsYearn || vault.Metadata.Inclusion.IsYearnJuiced || vault.Metadata.Inclusion.IsGimme

--- a/internal/models/vaults.go
+++ b/internal/models/vaults.go
@@ -73,6 +73,7 @@ type TInclusion struct {
 	IsPoolTogether  bool `json:"isPoolTogether"`  // If the vault is a PoolTogether vault or not
 	IsCove          bool `json:"isCove"`          // If the vault is a Cove related vault or not
 	IsMorpho        bool `json:"isMorpho"`        // If the vault is a Morpho vault or not
+	IsKatana        bool `json:"isKatana"`        // If the vault is a Katana vault or not
 	IsPublicERC4626 bool `json:"isPublicERC4626"` // If the vault is from the public ERC4626 registry or not
 }
 

--- a/scripts/verify-vaults.js
+++ b/scripts/verify-vaults.js
@@ -94,7 +94,8 @@ const vaultSchema = {
 						isPoolTogether: {type: 'boolean'},
 						isCove: {type: 'boolean'},
 						isMorpho: {type: 'boolean'},
-						isPublicERC4626: {type: 'boolean'}
+						isPublicERC4626: { type: 'boolean' },
+						isKatana: { type: 'boolean' }
 					},
 					required: [
 						'isSet',


### PR DESCRIPTION
Added a new `isKatana` flag in the vault metadata for Katana vaults.

Added new routes and data in other files as needed. Copied everything from the isMorpho flag.