### PR TITLE
fix: iscurve check to return false if no strats present

### DIFF
--- a/processes/apr/forward.curve.helpers.go
+++ b/processes/apr/forward.curve.helpers.go
@@ -20,21 +20,29 @@ not curve strategies, this returns false
 *************************************************************************************************
 */
 func isCurveVault(strategies map[string]models.TStrategy) bool {
+	hasActive := false
+
 	for _, strategy := range strategies {
 		// skip any strategy that has zero debt or isn’t active
 		if strategy.LastDebtRatio == nil ||
 			strategy.LastDebtRatio.IsZero() {
 			continue
 		}
+		hasActive = true
 
 		strategyName := strings.ToLower(strategy.Name)
 		if !(strings.Contains(strategyName, `curve`) ||
 			strings.Contains(strategyName, `convex`)) ||
 			strings.Contains(strategyName, `ajna-`) ||
 			!strategy.LastDebtRatio.Gt(bigNumber.NewInt(0)) {
-			return false // Return false if any strategy does not meet the criteria
+			return false // Return false if any active strategy does not meet the criteria
 		}
 	}
+	// if we never saw an active strategy, it’s not a Curve vault
+	if !hasActive {
+		return false
+	}
+
 	return true
 }
 


### PR DESCRIPTION
This PR fixes a bug with #470 where the `isCurveVault()` function was returning `true` if a vault had no strategies. It has been fixed to instead return `false` if there are no strategies, as our current implementation of curve vaults all use V2 and always have strategies. We should be aware of this behavior in the future if the curve factory is migrated to v3.