### PR TITLE
fix: put USDT in stablecoin category

### DIFF
--- a/data/meta/vaults/1.json
+++ b/data/meta/vaults/1.json
@@ -9155,7 +9155,7 @@
 				"stability": {
 					"stability": "Unknown"
 				},
-				"category": "auto",
+				"category": "Stablecoin",
 				"displayName": "USDT",
 				"displaySymbol": "yvUSDT-1",
 				"description": "Multi strategy USDT vault. \u003cbr/\u003e\u003cbr/\u003eMulti strategy vaults are (wait for it) vaults that contain multiple strategies. Multi strategy vaults give the vault creator flexibility to balance risk and opportunity across multiple different strategies.",

--- a/data/meta/vaults/42161.json
+++ b/data/meta/vaults/42161.json
@@ -4634,7 +4634,7 @@
 				"stability": {
 					"stability": "Unknown"
 				},
-				"category": "auto",
+				"category": "Stablecoin",
 				"displayName": "",
 				"displaySymbol": "",
 				"description": "Multi strategy USDT vault. \u003cbr/\u003e\u003cbr/\u003eMulti strategy vaults are (wait for it) vaults that contain multiple strategies. Multi strategy vaults give the vault creator flexibility to balance risk and opportunity across multiple different strategies.",


### PR DESCRIPTION
Fix bug where USDT vaults on mainnet and arbitrum were not listed in the stablecoin filter