### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/processes/prices/fetcher.coingecko.go
+++ b/processes/prices/fetcher.coingecko.go
@@ -54,10 +54,7 @@ func fetchPricesFromGecko(chainID uint64, tokens []models.TERC20Token) map[commo
 
 	for i := 0; i < len(tokens); i += chunkSize {
 		time.Sleep(time.Duration(timeToSleep) * time.Millisecond)
-		end := i + chunkSize
-		if end > len(tokens) {
-			end = len(tokens)
-		}
+		end := min(i+chunkSize, len(tokens))
 
 		tokensFromChunk := tokens[i:end]
 		var tokenString []string

--- a/processes/prices/fetcher.defillama.go
+++ b/processes/prices/fetcher.defillama.go
@@ -70,10 +70,7 @@ func fetchPricesFromLlama(chainID uint64, tokens []models.TERC20Token) map[commo
 	for i := 0; i < len(tokens); i += chunkSize {
 		time.Sleep(time.Duration(timeToSleep) * time.Millisecond)
 
-		end := i + chunkSize
-		if end > len(tokens) {
-			end = len(tokens)
-		}
+		end := min(i+chunkSize, len(tokens))
 
 		tokensFromChunk := tokens[i:end]
 		var tokenString []string

--- a/processes/prices/fetcher.lens.go
+++ b/processes/prices/fetcher.lens.go
@@ -56,10 +56,7 @@ func fetchPricesFromLens(chainID uint64, blockNumber *uint64, tokens []models.TE
 		******************************************************************************************/
 		grouped := [][]models.TERC20Token{}
 		for i := 0; i < len(tokens); i += 500 {
-			end := i + 500
-			if end > len(tokens) {
-				end = len(tokens)
-			}
+			end := min(i+500, len(tokens))
 			grouped = append(grouped, tokens[i:end])
 		}
 


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.
