### PR TITLE
fix: integrations

### DIFF
--- a/internal/models/vaults.go
+++ b/internal/models/vaults.go
@@ -244,6 +244,7 @@ type TVaultCmsMetadataSchema struct {
 	SourceURI      *string            `json:"sourceURI,omitempty"`
 	UINotice       *string            `json:"uiNotice,omitempty"`
 	Protocols      []TCmsProtocolType `json:"protocols"`
+	Inclusion      TInclusion         `json:"inclusion"`
 }
 
 type CoercibleUint64 struct {

--- a/internal/storage/elem.vaults.go
+++ b/internal/storage/elem.vaults.go
@@ -152,6 +152,16 @@ func ApplyCmsVaultMeta(vaultMeta models.TVaultCmsMetadataSchema, vault *models.T
 	// Apply struct fields
 	vault.Metadata.Migration = vaultMeta.Migration
 	vault.Metadata.Stability = vaultMeta.Stability
+	
+	vault.Metadata.Inclusion.IsYearn = vaultMeta.Inclusion.IsYearn
+	vault.Metadata.Inclusion.IsYearnJuiced = vaultMeta.Inclusion.IsYearnJuiced
+	vault.Metadata.Inclusion.IsGimme = vaultMeta.Inclusion.IsGimme
+	vault.Metadata.Inclusion.IsSet = vaultMeta.Inclusion.IsSet
+	vault.Metadata.Inclusion.IsPoolTogether = vaultMeta.Inclusion.IsPoolTogether
+	vault.Metadata.Inclusion.IsCove = vaultMeta.Inclusion.IsCove
+	vault.Metadata.Inclusion.IsMorpho = vaultMeta.Inclusion.IsMorpho
+	vault.Metadata.Inclusion.IsKatana = vaultMeta.Inclusion.IsKatana
+	vault.Metadata.Inclusion.IsPublicERC4626 = vaultMeta.Inclusion.IsPublicERC4626
 
 	// Apply string fields (handle nil pointers)
 	if vaultMeta.Category != nil {


### PR DESCRIPTION
This PR is aimed to fix an issue with some tokenized strategies being filtered out from ydaemon vaults response. 
There are might be 2 reasons for this:
- vault token is not fetched for that strategy yet and `CreateExternalVault` fails, which prevents the strategy to appear in response (just have to force/wait for `RetrieveAllTokens`)
- vault has wrong meta.inclusion. As far as I understood current [yearn.fi/v3 vault list](https://ydaemon.yearn.fi/vaults?hideAlways=true&orderBy=featuringScore&orderDirection=desc&strategiesDetails=withDetails&strategiesCondition=inQueue&chainIDs=1,10,137,146,250,8453,42161,747474&limit=2500) filters out some strategies because they have `isYearn: false` in internal data storage, while in both json meta and cms `isYearn` is true. I assumed that is because `inclusion` is not set correctly  