### PR TITLE
Add convex lender manually

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ GRAPH_API_URI=
 SENTRY_DSN=
 SENTRY_SAMPLE_RATE=
 LOG_LEVEL=          # DEBUG, INFO, WARNING, SUCCESS, ERROR
+RISK_CDN_URL=       # Risk score CDN URL (defaults to https://risk.yearn.fi/cdn/)
 ```
 
 ## Architecture Overview

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/yearn/ydaemon/common/ethereum"
 	"github.com/yearn/ydaemon/common/logs"
@@ -13,9 +15,18 @@ func processServer(chainID uint64) {
 	setStatusForChainID(chainID, `Loading`)
 	defer setStatusForChainID(chainID, `OK`)
 
+	logs.Info(`Initializing chain ` + strconv.FormatUint(chainID, 10) + ` indexing process`)
+	
+	logs.Info(`Setting up WebSocket client for chain ` + strconv.FormatUint(chainID, 10))
 	ethereum.GetWSClient(chainID, true)
+	
+	logs.Info(`Initializing block timestamps for chain ` + strconv.FormatUint(chainID, 10))
 	ethereum.InitBlockTimestamp(chainID)
+	
+	logs.Info(`Starting main indexer for chain ` + strconv.FormatUint(chainID, 10))
 	internal.InitializeV2(chainID, nil)
+	
+	logs.Info(`Chain ` + strconv.FormatUint(chainID, 10) + ` initialization completed`)
 	TriggerInitializedStatus(chainID)
 }
 
@@ -38,6 +49,7 @@ func main() {
 	go NewRouter().Run(`:` + port)
 	go TriggerTgMessage(`💛 - yDaemon v` + GetVersion() + ` is ready to accept requests: https://ydaemon.yearn.fi/`)
 
+	logs.Info(`Starting indexing processes for ` + strconv.Itoa(len(chains)) + ` chains: ` + fmt.Sprintf("%v", chains))
 	for _, chainID := range chains {
 		go processServer(chainID)
 	}

--- a/common/env/constants.go
+++ b/common/env/constants.go
@@ -80,3 +80,11 @@ var CG_DEMO_KEYS = []string{}
 ** ../webops-sdk/packages/cms/cdn/content
 **************************************************************************************************/
 var CMS_ROOT_URL = ``
+
+/**************************************************************************************************
+** RISK_CDN_URL contains the base URL for the risk score CDN.
+** This endpoint is used to fetch vault risk scores from the Yearn risk assessment system.
+** The risk scores are stored as JSON files organized by chain ID and vault address.
+** Default value points to the production CDN, but can be overridden via RISK_CDN_URL env variable.
+**************************************************************************************************/
+var RISK_CDN_URL = `https://risk.yearn.fi/cdn/`

--- a/common/env/environment.go
+++ b/common/env/environment.go
@@ -49,6 +49,13 @@ func SetEnv() {
 	if cmsRoot, exists := os.LookupEnv("CMS_ROOT_URL"); exists {
 		CMS_ROOT_URL = cmsRoot
 	}
+
+	/**********************************************************************************************
+	** Risk score CDN URL configuration
+	**********************************************************************************************/
+	if riskCDN, exists := os.LookupEnv("RISK_CDN_URL"); exists {
+		RISK_CDN_URL = riskCDN
+	}
 }
 
 /**************************************************************************************************

--- a/common/ethereum/blocktime.go
+++ b/common/ethereum/blocktime.go
@@ -256,6 +256,7 @@ func InitBlockTimeData() {
 		blocktimeSuccess(fmt.Sprintf("Chain %d - Loaded %d blocktime records", chainID, len(pairs)))
 
 		// Check if we need to update with newer data
+		logs.Info(`Chain ` + strconv.FormatUint(chainID, 10) + ` - Checking for blocktime data updates`)
 		updateBlocktimeUntilToday(chainID, pairs)
 	}
 
@@ -394,7 +395,9 @@ func updateBlocktimeUntilToday(chainID uint64, existingPairs []TimestampBlockPai
 
 	if len(existingPairs) == 0 {
 		blocktimeLog(fmt.Sprintf("Chain %d - No existing blocktime data, will populate from scratch", chainID))
+		logs.Info(`Chain ` + strconv.FormatUint(chainID, 10) + ` - Starting blocktime data population (this may take a while)`)
 		fetchBlocktimeForDateRange(chainID, nil, nil)
+		logs.Info(`Chain ` + strconv.FormatUint(chainID, 10) + ` - Completed blocktime data population`)
 		return
 	}
 
@@ -430,7 +433,9 @@ func updateBlocktimeUntilToday(chainID uint64, existingPairs []TimestampBlockPai
 		int(today.Sub(nextDay).Hours()/24)+1))
 
 	// Fetch data for the missing date range
+	logs.Info(`Chain ` + strconv.FormatUint(chainID, 10) + ` - Fetching missing blocktime data from ` + nextDay.Format("2006-01-02") + ` to ` + today.Format("2006-01-02"))
 	fetchBlocktimeForDateRange(chainID, &nextDay, &today)
+	logs.Info(`Chain ` + strconv.FormatUint(chainID, 10) + ` - Completed fetching missing blocktime data`)
 }
 
 /**************************************************************************************************

--- a/common/ethereum/initializer.go
+++ b/common/ethereum/initializer.go
@@ -48,11 +48,18 @@ func Initialize() {
 		)
 	}
 
-	// Initialize the internal block time data storage
-	InitBlockTimeData()
+	// Initialize the internal block time data storage in background
+	logs.Info(`Starting background blocktime data initialization`)
+	go func() {
+		InitBlockTimeData()
+		logs.Info(`Background blocktime data initialization completed`)
+	}()
 
-	// Initialize block timestamps for each supported chain
+	// Initialize block timestamps for each supported chain  
+	logs.Info(`Initializing block timestamps for all chains`)
 	for _, chain := range env.GetChains() {
+		logs.Info(`Initializing block timestamps for chain ` + strconv.FormatUint(chain.ID, 10))
 		InitBlockTimestamp(chain.ID)
 	}
+	logs.Info(`Completed blockchain initialization for all chains`)
 }

--- a/data/meta/strategies/1.manuals.json
+++ b/data/meta/strategies/1.manuals.json
@@ -1,0 +1,38 @@
+{
+	"lastUpdate": "2025-01-01T00:00:00.000000000Z",
+	"version": {
+		"major": 1,
+		"minor": 0,
+		"patch": 0
+	},
+	"shouldRefresh": false,
+	"strategies": {
+		"0xBaadd4b44929606178FcDBd2f4309282f39D9dA7_0xBF319dDC2Edc1Eb6FDf9910E39b37Be221C8805F": {
+			"address": "0xbaadd4b44929606178fcdbd2f4309282f39d9da7",
+			"vaultAddress": "0xbf319ddc2edc1eb6fdf9910e39b37be221c8805f",
+			"name": "Convex crvUSD-sreUSD Lender",
+			"vaultVersion": "3.0.2",
+			"displayName": "",
+			"description": "",
+			"activation": 23392354,
+			"chainID": 1,
+			"doHealthCheck": true,
+			"isActive": true,
+			"isInQueue": false,
+			"isRetired": false,
+			"status": "active",
+			"keepCRV": null,
+			"keepCRVPercent": null,
+			"keepCVX": null,
+			"lastTotalDebt": "293438835517089465378725",
+			"lastTotalLoss": "0",
+			"lastTotalGain": "0",
+			"lastPerformanceFee": "500",
+			"lastReport": "1758227339",
+			"lastDebtRatio": "978",
+			"netAPR": 0.1586453989870673,
+			"aprType": "forward",
+			"protocols": null
+		}
+	}
+}

--- a/internal/fetcher/helper.go
+++ b/internal/fetcher/helper.go
@@ -435,13 +435,13 @@ func handleV3VaultCalls(vault models.TVault, response map[string][]interface{}) 
 
 	// Append manual strategies if they exist for this vault (avoid duplicates)
 	manualStrategies := storage.GetManualStrategiesForVault(vault.ChainID, vault.Address)
-	seen := make(map[common.Address]struct{})
-	for _, s := range vault.LastActiveStrategies {
-		seen[s] = struct{}{}
+	isInDefaultQueue := make(map[common.Address]bool)
+	for _, strategy := range vault.LastActiveStrategies {
+		isInDefaultQueue[strategy] = true
 	}
-	for _, s := range manualStrategies {
-		if _, exists := seen[s]; !exists {
-			vault.LastActiveStrategies = append(vault.LastActiveStrategies, s)
+	for _, manualStrategy := range manualStrategies {
+		if !isInDefaultQueue[manualStrategy] {
+			vault.LastActiveStrategies = append(vault.LastActiveStrategies, manualStrategy)
 		}
 	}
 

--- a/internal/fetcher/strategies.go
+++ b/internal/fetcher/strategies.go
@@ -3,6 +3,7 @@ package fetcher
 import (
 	"errors"
 	"math"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/yearn/ydaemon/common/addresses"
 	"github.com/yearn/ydaemon/common/bigNumber"
 	"github.com/yearn/ydaemon/common/ethereum"
+	"github.com/yearn/ydaemon/common/logs"
 	"github.com/yearn/ydaemon/internal/models"
 	"github.com/yearn/ydaemon/internal/multicalls"
 	"github.com/yearn/ydaemon/internal/storage"
@@ -332,6 +334,8 @@ func RetrieveAllStrategies(
 	chainID uint64,
 	strategies map[string]models.TStrategy,
 ) map[string]models.TStrategy {
+	strategyCount := len(strategies)
+	logs.Info(`Fetching details for ` + strconv.Itoa(strategyCount) + ` strategies on chain ` + strconv.FormatUint(chainID, 10))
 	fetchStrategiesBasicInformations(chainID, strategies)
 
 	strategyMap, _ := storage.ListStrategies(chainID)

--- a/internal/fetcher/tokens.go
+++ b/internal/fetcher/tokens.go
@@ -608,6 +608,9 @@ func RetrieveAllTokens(
 	if !ok {
 		return map[common.Address]models.TERC20Token{}
 	}
+	
+	vaultCount := len(vaults)
+	logs.Info(`Fetching token information for vaults (` + strconv.Itoa(vaultCount) + ` vaults) on chain ` + strconv.FormatUint(chainID, 10))
 
 	/**********************************************************************************************
 	** First, try to retrieve the list of tokens from the database to exclude the one existing

--- a/internal/fetcher/vaults.go
+++ b/internal/fetcher/vaults.go
@@ -1,6 +1,7 @@
 package fetcher
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -47,7 +48,9 @@ func fetchVaultsBasicInformations(
 		chunks = append(chunks, vaultSlice[i:end])
 	}
 
-	for _, chunk := range chunks {
+	totalChunks := len(chunks)
+	for chunkIndex, chunk := range chunks {
+		logs.Info(`Processing vault chunk ` + strconv.Itoa(chunkIndex+1) + `/` + strconv.Itoa(totalChunks) + ` (` + strconv.Itoa(len(chunk)) + ` vaults)`)
 		/**********************************************************************************************
 		** The first step is to prepare the multicall, connecting to the multicall instance and
 		** preparing the array of calls to send. All calls for all vaults will be send in a single
@@ -121,6 +124,9 @@ func RetrieveAllVaults(
 		logs.Error(chainID, `-`, `RetrieveAllVaults`, `Chain not found`)
 		return nil
 	}
+	
+	vaultCount := len(vaults)
+	logs.Info(`Fetching details for ` + strconv.Itoa(vaultCount) + ` vaults on chain ` + strconv.FormatUint(chainID, 10))
 
 	/**********************************************************************************************
 	** First, try to retrieve the list of vaults from the database and populate our updatedVaultMap

--- a/internal/indexer/indexer.registries.go
+++ b/internal/indexer/indexer.registries.go
@@ -50,6 +50,9 @@ func filterNewVault(
 		blockEnd, _ := client.BlockNumber(context.Background())
 		end = &blockEnd
 	}
+	
+	blockRange := *end - start
+	logs.Info(`Scanning registry ` + registry.Address.Hex() + ` from block ` + strconv.FormatUint(start, 10) + ` to ` + strconv.FormatUint(*end, 10) + ` (` + strconv.FormatUint(blockRange, 10) + ` blocks)`)
 
 	for chunkStart := start; chunkStart < *end; chunkStart += chain.MaxBlockRange {
 		chunkEnd := chunkStart + chain.MaxBlockRange
@@ -601,6 +604,9 @@ func IndexNewVaults(chainID uint64) (vaultsFromRegistry map[common.Address]model
 		vaultsFromRegistry, _ = storage.ListVaultsFromRegistries(chainID)
 		return vaultsFromRegistry
 	}
+	
+	registryCount := len(chain.Registries)
+	logs.Info(`Starting vault registry scan for ` + strconv.Itoa(registryCount) + ` registries on chain ` + strconv.FormatUint(chainID, 10))
 
 	/** 🔵 - Yearn *********************************************************************************
 	** Loop over all the known registries for the specified chain ID.

--- a/internal/multicalls/perform.go
+++ b/internal/multicalls/perform.go
@@ -2,9 +2,12 @@ package multicalls
 
 import (
 	"math/big"
+	"strconv"
+	"time"
 
 	"github.com/yearn/ydaemon/common/env"
 	"github.com/yearn/ydaemon/common/ethereum"
+	"github.com/yearn/ydaemon/common/logs"
 )
 
 func Perform(chainID uint64, calls []ethereum.Call, blockNumber *big.Int) map[string][]interface{} {
@@ -13,6 +16,21 @@ func Perform(chainID uint64, calls []ethereum.Call, blockNumber *big.Int) map[st
 	if !ok {
 		return nil
 	}
-	batchSize := chain.MaxBatchSize
-	return caller.ExecuteByBatch(calls, batchSize, blockNumber)
+
+	callCount := len(calls)
+	if callCount > 0 {
+		logs.Info(`Executing multicall: ` + strconv.Itoa(callCount) + ` calls on chain ` + strconv.FormatUint(chainID, 10))
+		start := time.Now()
+
+		batchSize := chain.MaxBatchSize
+		result := caller.ExecuteByBatch(calls, batchSize, blockNumber)
+
+		elapsed := time.Since(start)
+		if elapsed > 500*time.Millisecond {
+			logs.Success(`Multicall completed in ` + strconv.FormatFloat(elapsed.Seconds(), 'f', 2, 64) + `s`)
+		}
+		return result
+	}
+
+	return nil
 }

--- a/processes/risks/main.go
+++ b/processes/risks/main.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/yearn/ydaemon/common/env"
 	"github.com/yearn/ydaemon/common/helpers"
 	"github.com/yearn/ydaemon/common/logs"
 	"github.com/yearn/ydaemon/internal/models"
@@ -49,8 +50,7 @@ type TGithubTreeResponse struct {
 ** - a TRiskScoreYsec structure containing the risk scores for the vault
 **************************************************************************************************/
 func fetchVaultsRiskScore(chainID uint64, vaultAddress common.Address) (TRiskScoreYsec, error) {
-	// baseURL := "https://raw.githubusercontent.com/yearn/risk-score/refs/heads/master/"
-	baseURL := "https://risk.yearn.fi/cdn/"
+	baseURL := env.RISK_CDN_URL
 	chainIDStr := strconv.FormatUint(chainID, 10)
 	vaultHex := vaultAddress.Hex()
 	vaultHexLower := strings.ToLower(vaultHex)


### PR DESCRIPTION
This PR introduces a manual strategy system to yDaemon for cases where strategies need to be explicitly included beyond auto-discovery.

Changes:
- Add support for {chainID}.manuals.json files to define human-curated strategies
- Implement GetManualStrategiesForVault() to fetch manual strategies per vault
- Integrate manual strategies into vault's LastActiveStrategies with deduplication
- Include first manual strategy: Convex crvUSD-sreUSD Lender (0xBaadd4b44929606178FcDBd2f4309282f39D9dA7)

to test, run ydaemon in dev as you normally would.