### PR TITLE
fix: crvUSD forwardAPY issue fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Repository Guidelines
+
+Please read CLAUDE.md, located in this same folder, for important information about this repo.

--- a/processes/apr/forward.curve.helpers.go
+++ b/processes/apr/forward.curve.helpers.go
@@ -318,6 +318,14 @@ func computeCurveLikeForwardAPY(
 	fraxPool := findFraxPoolForVault(vault.AssetAddress, fraxPools)
 	subgraphItem := findSubgraphItemForVault(common.HexToAddress(gauge.Swap), subgraphData)
 
+	/**********************************************************************************************
+	** If we can't resolve the gauge or pool for this vault, bail out so we don't clobber any
+	** previously computed forward APY (e.g. oracle based values).
+	**********************************************************************************************/
+	if gauge.Gauge == "" || pool.Address == "" {
+		return models.TForwardAPY{}
+	}
+
 	TypeOf := ``
 	netAPY := bigNumber.NewFloat(0)
 	boost := bigNumber.NewFloat(0)

--- a/processes/apr/main.go
+++ b/processes/apr/main.go
@@ -129,7 +129,7 @@ func ComputeChainAPY(chainID uint64) {
 		** We need to compute it and store it in our ForwardAPY structure.
 		**********************************************************************************************/
 		if isCurveVault(allStrategiesForVault) {
-			vaultAPY.ForwardAPY = computeCurveLikeForwardAPY(
+			forwardAPY := computeCurveLikeForwardAPY(
 				vault,
 				allStrategiesForVault,
 				gauges,
@@ -137,6 +137,9 @@ func ComputeChainAPY(chainID uint64) {
 				subgraphData,
 				fraxPools,
 			)
+			if forwardAPY.NetAPY != nil {
+				vaultAPY.ForwardAPY = forwardAPY
+			}
 		}
 
 		/**********************************************************************************************


### PR DESCRIPTION
- fix crvUSD not showing the correct forwardAPR. Because it has curve and convex strategies, it tries to calculate the forwardAPR with the curve logic that needs a gauge, etc. We should check if a guage exists and if not, skip to keep the normal v3 aprOracle data.

checked by running yDaemon locally. crvUSD forwardAPR data returned correctly.