### PR TITLE
Migrate vault and strategy discovery to Kong API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ RPC_URI_FOR_8453=   # Base
 RPC_URI_FOR_42161=  # Arbitrum
 
 # Optional
+KONG_API_URL=       # Kong GraphQL API (defaults to https://kong.yearn.farm/api/gql)
 WEBHOOK_SECRET=
 GRAPH_API_URI=
 SENTRY_DSN=

--- a/common/env/constants.go
+++ b/common/env/constants.go
@@ -88,3 +88,9 @@ var CMS_ROOT_URL = ``
 ** Default value points to the production CDN, but can be overridden via RISK_CDN_URL env variable.
 **************************************************************************************************/
 var RISK_CDN_URL = `https://risk.yearn.fi/cdn/`
+
+/**************************************************************************************************
+** KONG_API_URL contains the GraphQL endpoint for Kong, the single source of truth for vault
+** and strategy discovery. Defaults to https://kong.yearn.farm/api/gql
+**************************************************************************************************/
+var KONG_API_URL = `https://kong.yearn.farm/api/gql`

--- a/common/env/environment.go
+++ b/common/env/environment.go
@@ -56,6 +56,13 @@ func SetEnv() {
 	if riskCDN, exists := os.LookupEnv("RISK_CDN_URL"); exists {
 		RISK_CDN_URL = riskCDN
 	}
+
+	/**********************************************************************************************
+	** Kong API URL configuration
+	**********************************************************************************************/
+	if kongURL, exists := os.LookupEnv("KONG_API_URL"); exists {
+		KONG_API_URL = kongURL
+	}
 }
 
 /**************************************************************************************************

--- a/internal/indexer/indexer.kong.go
+++ b/internal/indexer/indexer.kong.go
@@ -1,0 +1,93 @@
+package indexer
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/yearn/ydaemon/common/addresses"
+	"github.com/yearn/ydaemon/common/logs"
+	"github.com/yearn/ydaemon/internal/kong"
+	"github.com/yearn/ydaemon/internal/models"
+	"github.com/yearn/ydaemon/internal/storage"
+)
+
+func IndexNewVaults(chainID uint64) map[common.Address]models.TVaultsFromRegistry {
+	logs.Info(chainID, `-`, `Fetching all vaults from Kong GraphQL API (single source of truth)`)
+	
+	kongVaultData, err := kong.FetchVaultsFromKong(chainID)
+	if err != nil {
+		logs.Error(chainID, `-`, `CRITICAL: Failed to fetch vaults from Kong: %v`, err)
+		logs.Error(chainID, `-`, `Cannot start yDaemon without Kong data - failing fast`)
+		panic(fmt.Sprintf("Kong GraphQL API unavailable for chain %d: %v", chainID, err))
+	}
+	
+	vaultsFromKong := make(map[common.Address]models.TVaultsFromRegistry)
+	
+	for vaultAddr, data := range kongVaultData {
+		// Create vault entry with Kong metadata
+		// Type and Kind will be populated by CMS metadata refresh
+		vault := models.TVaultsFromRegistry{
+			Address:         vaultAddr,
+			RegistryAddress: data.Vault.GetRegistry(),
+			TokenAddress:    data.Vault.GetAssetAddress(), // From Kong asset field
+			Type:            models.TokenTypeStandardVault, // Default, overridden by CMS
+			Kind:            models.VaultKindMultiple,      // Default, overridden by CMS
+			APIVersion:      data.Vault.APIVersion,         // From Kong apiVersion field
+			ChainID:         chainID,
+			BlockNumber:     data.Vault.GetBlockNumber(),
+			ExtraProperties: models.TExtraProperties{},
+		}
+		
+		vaultsFromKong[vaultAddr] = vault
+		storage.StoreNewVaultToRegistry(chainID, vault)
+	}
+	
+	logs.Success(chainID, `-`, `Indexed %d vaults from Kong (complete replacement)`, len(vaultsFromKong))
+	return vaultsFromKong
+}
+
+func IndexNewStrategies(chainID uint64, vaultMap map[common.Address]models.TVault) map[string]models.TStrategy {
+	logs.Info(chainID, `-`, `Fetching all strategies from Kong GraphQL API (single source of truth)`)
+	
+	kongVaultData, err := kong.FetchVaultsFromKong(chainID)
+	if err != nil {
+		logs.Error(chainID, `-`, `CRITICAL: Failed to fetch strategies from Kong: %v`, err)
+		logs.Error(chainID, `-`, `Cannot start yDaemon without Kong data - failing fast`)
+		panic(fmt.Sprintf("Kong GraphQL API unavailable for chain %d: %v", chainID, err))
+	}
+	
+	strategiesMap := make(map[string]models.TStrategy)
+	totalStrategies := 0
+	
+	for vaultAddr, data := range kongVaultData {
+		vault, exists := vaultMap[vaultAddr]
+		if !exists {
+			// If vault doesn't exist in our map, skip its strategies
+			continue
+		}
+		
+		for _, strategyAddr := range data.Strategies {
+			if addresses.Equals(strategyAddr, common.Address{}) {
+				continue
+			}
+			
+			strategy := models.TStrategy{
+				Address:      strategyAddr,
+				ChainID:      chainID,
+				VaultVersion: vault.Version,
+				VaultAddress: vaultAddr,
+				Activation:   vault.Activation,
+			}
+			
+			// Use combination of strategy and vault address as key to handle 
+			// strategies that may be used by multiple vaults
+			key := strategyAddr.Hex() + "_" + vaultAddr.Hex()
+			strategiesMap[key] = strategy
+			totalStrategies++
+		}
+	}
+	
+	logs.Success(chainID, `-`, `Indexed %d strategies from Kong (complete replacement)`, totalStrategies)
+	return strategiesMap
+}
+

--- a/internal/indexer/indexer.registries.go
+++ b/internal/indexer/indexer.registries.go
@@ -586,7 +586,7 @@ func indexNewVaultsWrapper(
 **   - Listen to new vaults added to the registry (aka listening to the events)
 ** Only the first group is stored in the `sync.Map`.
 **************************************************************************************************/
-func IndexNewVaults(chainID uint64) (vaultsFromRegistry map[common.Address]models.TVaultsFromRegistry) {
+func IndexNewVaultsFromRegistries(chainID uint64) (vaultsFromRegistry map[common.Address]models.TVaultsFromRegistry) {
 	shouldSkipIndexing := false
 	wg := sync.WaitGroup{} // This WaitGroup will be done when all the historical vaults are indexed
 

--- a/internal/indexer/indexer.strategies.go
+++ b/internal/indexer/indexer.strategies.go
@@ -671,7 +671,7 @@ func indexStrategyWrapper(
 /** 🔵 - Yearn *************************************************************************************
 ** The function `IndexNewStrategies` is responsible for indexing new strategies for a given chain ID.
 **************************************************************************************************/
-func IndexNewStrategies(
+func IndexNewStrategiesFromContracts(
 	chainID uint64,
 	vaults map[common.Address]models.TVault,
 ) (historicalStrategiesMap map[string]models.TStrategy) {

--- a/internal/kong/client.go
+++ b/internal/kong/client.go
@@ -11,12 +11,12 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/yearn/ydaemon/common/env"
 	"github.com/yearn/ydaemon/common/logs"
 )
 
 const (
-	KongGraphQLEndpoint = "https://kong.yearn.farm/api/gql"
-	DefaultTimeout      = 30 * time.Second
+	DefaultTimeout = 30 * time.Second
 )
 
 type GraphQLRequest struct {
@@ -65,7 +65,7 @@ func NewClient() *Client {
 		httpClient: &http.Client{
 			Timeout: DefaultTimeout,
 		},
-		endpoint: KongGraphQLEndpoint,
+		endpoint: env.KONG_API_URL,
 	}
 }
 

--- a/internal/kong/client.go
+++ b/internal/kong/client.go
@@ -1,0 +1,300 @@
+package kong
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/yearn/ydaemon/common/logs"
+)
+
+const (
+	KongGraphQLEndpoint = "https://kong.yearn.farm/api/gql"
+	DefaultTimeout      = 30 * time.Second
+)
+
+type GraphQLRequest struct {
+	Query     string                 `json:"query"`
+	Variables map[string]interface{} `json:"variables,omitempty"`
+}
+
+type GraphQLResponse struct {
+	Data   json.RawMessage `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors,omitempty"`
+}
+
+type KongAsset struct {
+	ChainID  int    `json:"chainId"`
+	Address  string `json:"address"`
+	Decimals int    `json:"decimals"`
+	Name     string `json:"name"`
+	Symbol   string `json:"symbol"`
+}
+
+type KongVault struct {
+	Address           string    `json:"address"`
+	ChainID           int       `json:"chainId"`
+	Asset             KongAsset `json:"asset"`
+	Registry          string    `json:"registry"`
+	InceptBlock       string    `json:"inceptBlock"`
+	APIVersion        string    `json:"apiVersion"`
+	WithdrawalQueue   []string  `json:"withdrawalQueue"`
+	GetDefaultQueue   []string  `json:"get_default_queue"`
+	Strategies        []string  `json:"strategies"`
+}
+
+type VaultsResponse struct {
+	Vaults []KongVault `json:"vaults"`
+}
+
+type Client struct {
+	httpClient *http.Client
+	endpoint   string
+}
+
+func NewClient() *Client {
+	return &Client{
+		httpClient: &http.Client{
+			Timeout: DefaultTimeout,
+		},
+		endpoint: KongGraphQLEndpoint,
+	}
+}
+
+func (c *Client) executeQuery(ctx context.Context, query string, variables map[string]interface{}) (*GraphQLResponse, error) {
+	request := GraphQLRequest{
+		Query:     query,
+		Variables: variables,
+	}
+
+	reqBody, err := json.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", c.endpoint, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	var graphQLResp GraphQLResponse
+	if err := json.Unmarshal(body, &graphQLResp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	if len(graphQLResp.Errors) > 0 {
+		return nil, fmt.Errorf("GraphQL errors: %v", graphQLResp.Errors)
+	}
+
+	return &graphQLResp, nil
+}
+
+func (c *Client) FetchVaultsForChain(ctx context.Context, chainID uint64) ([]KongVault, error) {
+	query := `
+		query FetchVaults($chainId: Int!) {
+			vaults(chainId: $chainId, yearn: true) {
+				address
+				chainId
+				asset {
+					chainId
+					address
+					decimals
+					name
+					symbol
+				}
+				registry
+				inceptBlock
+				apiVersion
+				withdrawalQueue
+				get_default_queue
+				strategies
+			}
+		}
+	`
+
+	variables := map[string]interface{}{
+		"chainId": int(chainID),
+	}
+
+	resp, err := c.executeQuery(ctx, query, variables)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch vaults for chain %d: %w", chainID, err)
+	}
+
+	var vaultsResp VaultsResponse
+	if err := json.Unmarshal(resp.Data, &vaultsResp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal vaults response: %w", err)
+	}
+
+	return vaultsResp.Vaults, nil
+}
+
+func (c *Client) FetchAllVaults(ctx context.Context) (map[uint64][]KongVault, error) {
+	query := `
+		query FetchAllVaults {
+			vaults(yearn: true) {
+				address
+				chainId
+				asset {
+					chainId
+					address
+					decimals
+					name
+					symbol
+				}
+				registry
+				inceptBlock
+				apiVersion
+				withdrawalQueue
+				get_default_queue
+				strategies
+			}
+		}
+	`
+
+	resp, err := c.executeQuery(ctx, query, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch all vaults: %w", err)
+	}
+
+	var vaultsResp VaultsResponse
+	if err := json.Unmarshal(resp.Data, &vaultsResp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal vaults response: %w", err)
+	}
+
+	vaultsByChain := make(map[uint64][]KongVault)
+	for _, vault := range vaultsResp.Vaults {
+		chainID := uint64(vault.ChainID)
+		vaultsByChain[chainID] = append(vaultsByChain[chainID], vault)
+	}
+
+	return vaultsByChain, nil
+}
+
+func (v *KongVault) GetAddress() common.Address {
+	return common.HexToAddress(v.Address)
+}
+
+func (v *KongVault) GetRegistry() common.Address {
+	if v.Registry == "" {
+		return common.Address{}
+	}
+	return common.HexToAddress(v.Registry)
+}
+
+func (v *KongVault) GetBlockNumber() uint64 {
+	if v.InceptBlock == "" {
+		return 0
+	}
+	blockNum, err := strconv.ParseUint(v.InceptBlock, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return blockNum
+}
+
+func (v *KongVault) GetAssetAddress() common.Address {
+	if v.Asset.Address == "" {
+		return common.Address{}
+	}
+	return common.HexToAddress(v.Asset.Address)
+}
+
+func (v *KongVault) GetStrategies() []common.Address {
+	strategySet := make(map[common.Address]bool)
+	var strategies []common.Address
+	
+	// Combine strategies from all available sources (not prioritized fallback)
+	// This matches the original yDaemon approach of getting all strategies
+	
+	// Add from WithdrawalQueue
+	if v.WithdrawalQueue != nil && len(v.WithdrawalQueue) > 0 {
+		for _, s := range v.WithdrawalQueue {
+			if s != "" && s != "0x0000000000000000000000000000000000000000" {
+				addr := common.HexToAddress(s)
+				if !strategySet[addr] {
+					strategySet[addr] = true
+					strategies = append(strategies, addr)
+				}
+			}
+		}
+	}
+	
+	// Add from GetDefaultQueue
+	if v.GetDefaultQueue != nil && len(v.GetDefaultQueue) > 0 {
+		for _, s := range v.GetDefaultQueue {
+			if s != "" && s != "0x0000000000000000000000000000000000000000" {
+				addr := common.HexToAddress(s)
+				if !strategySet[addr] {
+					strategySet[addr] = true
+					strategies = append(strategies, addr)
+				}
+			}
+		}
+	}
+	
+	// Add from Strategies
+	if v.Strategies != nil && len(v.Strategies) > 0 {
+		for _, s := range v.Strategies {
+			if s != "" && s != "0x0000000000000000000000000000000000000000" {
+				addr := common.HexToAddress(s)
+				if !strategySet[addr] {
+					strategySet[addr] = true
+					strategies = append(strategies, addr)
+				}
+			}
+		}
+	}
+	
+	return strategies
+}
+
+type KongVaultData struct {
+	Vault      KongVault
+	Strategies []common.Address
+}
+
+func FetchVaultsFromKong(chainID uint64) (map[common.Address]KongVaultData, error) {
+	ctx := context.Background()
+	client := NewClient()
+	
+	vaults, err := client.FetchVaultsForChain(ctx, chainID)
+	if err != nil {
+		logs.Error(chainID, `-`, `Failed to fetch vaults from Kong: %v`, err)
+		return nil, err
+	}
+	
+	vaultData := make(map[common.Address]KongVaultData)
+	for _, vault := range vaults {
+		vaultAddr := vault.GetAddress()
+		strategies := vault.GetStrategies()
+		vaultData[vaultAddr] = KongVaultData{
+			Vault:      vault,
+			Strategies: strategies,
+		}
+	}
+	
+	logs.Success(chainID, `-`, `Fetched %d vaults from Kong`, len(vaults))
+	return vaultData, nil
+}

--- a/internal/main.go
+++ b/internal/main.go
@@ -39,15 +39,15 @@ func initVaults(chainID uint64) (
 ) {
 	/** 🔵 - Yearn *************************************************************************************
 	** InitializeV2 is only called on initialization. It's first job is to retrieve the initial data:
-	** - The registries vaults
-	** - The vaults
-	** - The strategies
+	** - The vaults (from Kong, complete replacement for registry discovery)
+	** - The strategies (from Kong, complete replacement for contract querying)
 	** - The tokens
 	**************************************************************************************************/
 	indexer.IndexYearnXPoolTogetherVaults(chainID)
 	indexer.IndexYearnXCoveVaults(chainID)
+	// Use Kong as complete replacement for registry discovery
 	registries := indexer.IndexNewVaults(chainID)
-	logs.Success(chainID, `-`, `InitRegistries ✅`, len(registries))
+	logs.Success(chainID, `-`, `InitVaults (Kong) ✅`, len(registries))
 	vaultMap, strategiesMap := indexer.ProcessNewVault(chainID, registries, fetcher.ProcessNewVaultMethodReplace)
 	logs.Success(chainID, `-`, `InitVaults ✅`, len(vaultMap))
 	tokenMap := fetcher.RetrieveAllTokens(chainID, vaultMap)
@@ -58,11 +58,11 @@ func initVaults(chainID uint64) (
 func initStrategies(chainID uint64, vaultMap map[common.Address]models.TVault) {
 	/** 🔵 - Yearn *************************************************************************************
 	** initStrategies is only called on initialization. It's first job is to retrieve the strategies
-	** and then to schedule the retrieval of the strategies every 3 hours
+	** from Kong (complete replacement for contract querying), then to schedule retrieval
 	**************************************************************************************************/
 	strategiesMap := indexer.IndexNewStrategies(chainID, vaultMap)
 	fetcher.RetrieveAllStrategies(chainID, strategiesMap)
-	logs.Success(chainID, `-`, `InitStrategies ✅`, len(strategiesMap))
+	logs.Success(chainID, `-`, `InitStrategies (Kong) ✅`, len(strategiesMap))
 }
 
 func InitializeV2(chainID uint64, wg *sync.WaitGroup) {

--- a/processes/apr/current.strategy.kong.go
+++ b/processes/apr/current.strategy.kong.go
@@ -14,7 +14,6 @@ import (
 	"github.com/yearn/ydaemon/internal/storage"
 )
 
-const KONG_API_URL = "https://kong.yearn.farm/api/gql"
 
 /**************************************************************************************************
 ** getKongStrategyReport retrieves the latest strategy report from Kong API
@@ -29,7 +28,7 @@ func getKongStrategyReport(strategyAddress string, chainID uint64) (models.TRepo
 	query := fmt.Sprintf(`{"query":"query Query {\n  strategy(address: \"%s\", chainId: %d) {\n    lastReportDetail {\n      apr {\n        net\n        gross\n      }\n      loss\n      lossUsd\n      profit\n      profitUsd\n      blockTime\n      blockNumber\n    }\n    address\n  }\n}","variables":{"chainId":%d,"address":"%s"},"operationName":"Query"}`,
 		strategyAddress, chainID, chainID, strategyAddress)
 
-	req, err := http.NewRequest("POST", KONG_API_URL, strings.NewReader(query))
+	req, err := http.NewRequest("POST", env.KONG_API_URL, strings.NewReader(query))
 	if err != nil {
 		return models.TReportsFromKong{}, err
 	}

--- a/scripts/kong-integration/.gitignore
+++ b/scripts/kong-integration/.gitignore
@@ -1,0 +1,6 @@
+# Comparison report files
+*.txt
+
+# Temporary comparison files
+/tmp/kong_*
+/tmp/prod_*

--- a/scripts/kong-integration/compare-strategies.ts
+++ b/scripts/kong-integration/compare-strategies.ts
@@ -1,0 +1,243 @@
+#!/usr/bin/env bun
+
+/**
+ * Simple script to compare strategy lists between Kong-powered yDaemon and production
+ * Usage: bun scripts/kong-integration/compare-strategies.ts [chainId] [localPort]
+ */
+
+const chainId = process.argv[2] || "all";
+const localPort = process.argv[3] || "3001";
+
+// Supported chains from daemon logs
+const supportedChains = ["1", "10", "42161", "100", "137", "146", "250", "8453", "747474"];
+
+if (chainId === "all") {
+  console.log(`🔍 Comparing strategies for ALL chains`);
+  console.log(`📍 Local port: ${localPort}`);
+  console.log(`📍 Testing chains: ${supportedChains.join(", ")}`);
+  console.log();
+} else {
+  const localUrl = `http://localhost:${localPort}/${chainId}/strategies/all?limit=1000`;
+  const prodUrl = `https://ydaemon.yearn.fi/${chainId}/strategies/all?limit=1000`;
+  
+  console.log(`🔍 Comparing strategies for chain ${chainId}`);
+  console.log(`📍 Local (Kong):  ${localUrl}`);
+  console.log(`📍 Production:     ${prodUrl}`);
+  console.log();
+}
+
+async function fetchStrategies(url: string): Promise<string[]> {
+  const response = await fetch(url);
+  const strategies = await response.json();
+  return strategies.map((s: any) => s.address.toLowerCase()).sort();
+}
+
+async function checkKongDirectly(strategyAddress: string): Promise<boolean> {
+  const query = `{
+    strategies(yearn: true) {
+      address
+      chainId
+    }
+  }`;
+
+  const response = await fetch("https://kong.yearn.farm/api/gql", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ query }),
+  });
+
+  const data = await response.json();
+  return data.data.strategies.some((s: any) => s.address.toLowerCase() === strategyAddress.toLowerCase());
+}
+
+async function compareChain(chain: string) {
+  const localUrl = `http://localhost:${localPort}/${chain}/strategies/all?limit=1000`;
+  const prodUrl = `https://ydaemon.yearn.fi/${chain}/strategies/all?limit=1000`;
+  
+  console.log(`\n=== Chain ${chain} ===`);
+  console.log(`📍 Local:  ${localUrl}`);
+  console.log(`📍 Prod:   ${prodUrl}`);
+  
+  try {
+    const [kongStrategies, prodStrategies] = await Promise.all([
+      fetchStrategies(localUrl),
+      fetchStrategies(prodUrl),
+    ]);
+
+    const kongSet = new Set(kongStrategies);
+    const prodSet = new Set(prodStrategies);
+    
+    const missingFromKong = prodStrategies.filter(s => !kongSet.has(s));
+    const missingFromProd = kongStrategies.filter(s => !prodSet.has(s));
+    const common = kongStrategies.filter(s => prodSet.has(s));
+
+    console.log(`📊 Kong: ${kongStrategies.length}, Prod: ${prodStrategies.length}, Common: ${common.length}`);
+    
+    if (missingFromKong.length > 0) {
+      console.log(`❌ ${missingFromKong.length} missing from Kong`);
+    }
+    
+    if (missingFromProd.length > 0) {
+      console.log(`❌ ${missingFromProd.length} missing from Prod`);
+    }
+    
+    if (missingFromKong.length === 0 && missingFromProd.length === 0) {
+      console.log(`✅ Perfect match!`);
+    }
+    
+    return {
+      chain,
+      kongCount: kongStrategies.length,
+      prodCount: prodStrategies.length,
+      commonCount: common.length,
+      missingFromKong: missingFromKong.length,
+      missingFromProd: missingFromProd.length,
+      success: true
+    };
+  } catch (error) {
+    console.log(`❌ Error: ${error}`);
+    return {
+      chain,
+      kongCount: 0,
+      prodCount: 0,
+      commonCount: 0,
+      missingFromKong: 0,
+      missingFromProd: 0,
+      success: false,
+      error: error.toString()
+    };
+  }
+}
+
+async function main() {
+  if (chainId === "all") {
+    console.log("📥 Testing all chains...");
+    
+    const results = [];
+    for (const chain of supportedChains) {
+      const result = await compareChain(chain);
+      results.push(result);
+    }
+    
+    console.log("\n🏁 Summary:");
+    console.log("Chain | Kong | Prod | Common | Missing Kong | Missing Prod | Status");
+    console.log("------|------|------|--------|--------------|--------------|-------");
+    
+    let reportLines = [`Strategy Comparison Report - ${new Date().toISOString()}`, "", "Chain | Kong | Prod | Common | Missing Kong | Missing Prod | Status", "------|------|------|--------|--------------|--------------|-------"];
+    
+    for (const result of results) {
+      const status = result.success ? 
+        (result.missingFromKong === 0 && result.missingFromProd === 0 ? "✅ Match" : "⚠️  Diff") : 
+        "❌ Error";
+      const line = `${result.chain.padEnd(5)} | ${result.kongCount.toString().padEnd(4)} | ${result.prodCount.toString().padEnd(4)} | ${result.commonCount.toString().padEnd(6)} | ${result.missingFromKong.toString().padEnd(12)} | ${result.missingFromProd.toString().padEnd(12)} | ${status}`;
+      console.log(line);
+      reportLines.push(line);
+    }
+    
+    // Add detailed differences section
+    reportLines.push("", "=".repeat(80), "DETAILED DIFFERENCES BY CHAIN", "=".repeat(80));
+    
+    for (const result of results) {
+      if (result.missingFromKong > 0 || result.missingFromProd > 0) {
+        reportLines.push(``, `Chain ${result.chain}:`);
+        
+        if (result.missingFromKong > 0) {
+          reportLines.push(`  Missing from Kong (${result.missingFromKong}):`);
+          // We need to re-fetch to get the actual addresses
+          try {
+            const localUrl = `http://localhost:${localPort}/${result.chain}/strategies/all?limit=1000`;
+            const prodUrl = `https://ydaemon.yearn.fi/${result.chain}/strategies/all?limit=1000`;
+            const [kongStrategies, prodStrategies] = await Promise.all([
+              fetchStrategies(localUrl),
+              fetchStrategies(prodUrl),
+            ]);
+            const kongSet = new Set(kongStrategies);
+            const missingFromKong = prodStrategies.filter(s => !kongSet.has(s));
+            missingFromKong.forEach(addr => reportLines.push(`    ${addr}`));
+          } catch (e) {
+            reportLines.push(`    Error fetching details: ${e}`);
+          }
+        }
+        
+        if (result.missingFromProd > 0) {
+          reportLines.push(`  Missing from Production (${result.missingFromProd}):`);
+          try {
+            const localUrl = `http://localhost:${localPort}/${result.chain}/strategies/all?limit=1000`;
+            const prodUrl = `https://ydaemon.yearn.fi/${result.chain}/strategies/all?limit=1000`;
+            const [kongStrategies, prodStrategies] = await Promise.all([
+              fetchStrategies(localUrl),
+              fetchStrategies(prodUrl),
+            ]);
+            const prodSet = new Set(prodStrategies);
+            const missingFromProd = kongStrategies.filter(s => !prodSet.has(s));
+            missingFromProd.forEach(addr => reportLines.push(`    ${addr}`));
+          } catch (e) {
+            reportLines.push(`    Error fetching details: ${e}`);
+          }
+        }
+      }
+    }
+    
+    // Save report to file
+    const reportPath = "/home/murdertxxth/git/ydaemon/scripts/kong-integration/compare-strategies.txt";
+    await Bun.write(reportPath, reportLines.join("\n"));
+    console.log(`\n📄 Report saved: ${reportPath}`);
+    
+  } else {
+    // Single chain mode
+    const localUrl = `http://localhost:${localPort}/${chainId}/strategies/all?limit=1000`;
+    const prodUrl = `https://ydaemon.yearn.fi/${chainId}/strategies/all?limit=1000`;
+    
+    console.log("📥 Fetching strategy lists...");
+    
+    const [kongStrategies, prodStrategies] = await Promise.all([
+      fetchStrategies(localUrl),
+      fetchStrategies(prodUrl),
+    ]);
+
+    console.log("📊 Strategy counts:");
+    console.log(`   Kong (local):  ${kongStrategies.length} strategies`);
+    console.log(`   Production:    ${prodStrategies.length} strategies`);
+    console.log();
+
+    // Find differences
+    const kongSet = new Set(kongStrategies);
+    const prodSet = new Set(prodStrategies);
+    
+    const missingFromKong = prodStrategies.filter(s => !kongSet.has(s));
+    const missingFromProd = kongStrategies.filter(s => !prodSet.has(s));
+    const common = kongStrategies.filter(s => prodSet.has(s));
+
+    console.log("📈 Differences:");
+    console.log(`   Common strategies:        ${common.length}`);
+    console.log(`   Missing from Kong:        ${missingFromKong.length}`);
+    console.log(`   Missing from Prod:        ${missingFromProd.length}`);
+    console.log();
+
+    if (missingFromKong.length > 0) {
+      console.log("🔻 Strategies in production but missing from Kong:");
+      missingFromKong.slice(0, 10).forEach(s => console.log(`   ${s}`));
+      if (missingFromKong.length > 10) console.log(`   ... and ${missingFromKong.length - 10} more`);
+      console.log();
+    }
+
+    if (missingFromProd.length > 0) {
+      console.log("🔺 Strategies in Kong but missing from production:");
+      missingFromProd.slice(0, 10).forEach(s => console.log(`   ${s}`));
+      if (missingFromProd.length > 10) console.log(`   ... and ${missingFromProd.length - 10} more`);
+      console.log();
+    }
+
+    console.log();
+    console.log("✅ Comparison complete!");
+    
+    // Save to files for further analysis
+    await Bun.write(`/tmp/kong_strategies_${chainId}.txt`, kongStrategies.join("\n"));
+    await Bun.write(`/tmp/prod_strategies_${chainId}.txt`, prodStrategies.join("\n"));
+    console.log(`📁 Files saved:`);
+    console.log(`   Kong strategies:     /tmp/kong_strategies_${chainId}.txt`);
+    console.log(`   Production strategies: /tmp/prod_strategies_${chainId}.txt`);
+  }
+}
+
+main().catch(console.error);

--- a/scripts/kong-integration/compare-vaults.ts
+++ b/scripts/kong-integration/compare-vaults.ts
@@ -1,0 +1,261 @@
+#!/usr/bin/env bun
+
+/**
+ * Simple script to compare vault lists between Kong-powered yDaemon and production
+ * Usage: bun scripts/kong-integration/compare-vaults.ts [chainId] [localPort]
+ */
+
+const chainId = process.argv[2] || "all";
+const localPort = process.argv[3] || "3001";
+
+// Supported chains from daemon logs
+const supportedChains = ["1", "10", "42161", "100", "137", "146", "250", "8453", "747474"];
+
+if (chainId === "all") {
+  console.log(`🔍 Comparing vaults for ALL chains`);
+  console.log(`📍 Local port: ${localPort}`);
+  console.log(`📍 Testing chains: ${supportedChains.join(", ")}`);
+  console.log();
+} else {
+  const localUrl = `http://localhost:${localPort}/${chainId}/vaults/all?limit=1000`;
+  const prodUrl = `https://ydaemon.yearn.fi/${chainId}/vaults/all?limit=1000`;
+  
+  console.log(`🔍 Comparing vaults for chain ${chainId}`);
+  console.log(`📍 Local (Kong):  ${localUrl}`);
+  console.log(`📍 Production:     ${prodUrl}`);
+  console.log();
+}
+
+async function fetchVaults(url: string): Promise<string[]> {
+  const response = await fetch(url);
+  const vaults = await response.json();
+  return vaults.map((v: any) => v.address.toLowerCase()).sort();
+}
+
+async function checkKongDirectly(vaultAddress: string): Promise<boolean> {
+  const query = `{
+    vaults(yearn: true) {
+      address
+      chainId
+    }
+  }`;
+
+  const response = await fetch("https://kong.yearn.farm/api/gql", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ query }),
+  });
+
+  const data = await response.json();
+  return data.data.vaults.some((v: any) => v.address.toLowerCase() === vaultAddress.toLowerCase());
+}
+
+async function compareChain(chain: string) {
+  const localUrl = `http://localhost:${localPort}/${chain}/vaults/all?limit=1000`;
+  const prodUrl = `https://ydaemon.yearn.fi/${chain}/vaults/all?limit=1000`;
+  
+  console.log(`\n=== Chain ${chain} ===`);
+  console.log(`📍 Local:  ${localUrl}`);
+  console.log(`📍 Prod:   ${prodUrl}`);
+  
+  try {
+    const [kongVaults, prodVaults] = await Promise.all([
+      fetchVaults(localUrl),
+      fetchVaults(prodUrl),
+    ]);
+
+    const kongSet = new Set(kongVaults);
+    const prodSet = new Set(prodVaults);
+    
+    const missingFromKong = prodVaults.filter(v => !kongSet.has(v));
+    const missingFromProd = kongVaults.filter(v => !prodSet.has(v));
+    const common = kongVaults.filter(v => prodSet.has(v));
+
+    console.log(`📊 Kong: ${kongVaults.length}, Prod: ${prodVaults.length}, Common: ${common.length}`);
+    
+    if (missingFromKong.length > 0) {
+      console.log(`❌ ${missingFromKong.length} missing from Kong`);
+    }
+    
+    if (missingFromProd.length > 0) {
+      console.log(`❌ ${missingFromProd.length} missing from Prod`);
+    }
+    
+    if (missingFromKong.length === 0 && missingFromProd.length === 0) {
+      console.log(`✅ Perfect match!`);
+    }
+    
+    return {
+      chain,
+      kongCount: kongVaults.length,
+      prodCount: prodVaults.length,
+      commonCount: common.length,
+      missingFromKong: missingFromKong.length,
+      missingFromProd: missingFromProd.length,
+      success: true
+    };
+  } catch (error) {
+    console.log(`❌ Error: ${error}`);
+    return {
+      chain,
+      kongCount: 0,
+      prodCount: 0,
+      commonCount: 0,
+      missingFromKong: 0,
+      missingFromProd: 0,
+      success: false,
+      error: error.toString()
+    };
+  }
+}
+
+async function main() {
+  if (chainId === "all") {
+    console.log("📥 Testing all chains...");
+    
+    const results = [];
+    for (const chain of supportedChains) {
+      const result = await compareChain(chain);
+      results.push(result);
+    }
+    
+    console.log("\n🏁 Summary:");
+    console.log("Chain | Kong | Prod | Common | Missing Kong | Missing Prod | Status");
+    console.log("------|------|------|--------|--------------|--------------|-------");
+    
+    let reportLines = [`Vault Comparison Report - ${new Date().toISOString()}`, "", "Chain | Kong | Prod | Common | Missing Kong | Missing Prod | Status", "------|------|------|--------|--------------|--------------|-------"];
+    
+    for (const result of results) {
+      const status = result.success ? 
+        (result.missingFromKong === 0 && result.missingFromProd === 0 ? "✅ Match" : "⚠️  Diff") : 
+        "❌ Error";
+      const line = `${result.chain.padEnd(5)} | ${result.kongCount.toString().padEnd(4)} | ${result.prodCount.toString().padEnd(4)} | ${result.commonCount.toString().padEnd(6)} | ${result.missingFromKong.toString().padEnd(12)} | ${result.missingFromProd.toString().padEnd(12)} | ${status}`;
+      console.log(line);
+      reportLines.push(line);
+    }
+    
+    // Add detailed differences section
+    reportLines.push("", "=".repeat(80), "DETAILED DIFFERENCES BY CHAIN", "=".repeat(80));
+    
+    for (const result of results) {
+      if (result.missingFromKong > 0 || result.missingFromProd > 0) {
+        reportLines.push(``, `Chain ${result.chain}:`);
+        
+        if (result.missingFromKong > 0) {
+          reportLines.push(`  Missing from Kong (${result.missingFromKong}):`);
+          // We need to re-fetch to get the actual addresses
+          try {
+            const localUrl = `http://localhost:${localPort}/${result.chain}/vaults/all?limit=1000`;
+            const prodUrl = `https://ydaemon.yearn.fi/${result.chain}/vaults/all?limit=1000`;
+            const [kongVaults, prodVaults] = await Promise.all([
+              fetchVaults(localUrl),
+              fetchVaults(prodUrl),
+            ]);
+            const kongSet = new Set(kongVaults);
+            const missingFromKong = prodVaults.filter(v => !kongSet.has(v));
+            missingFromKong.forEach(addr => reportLines.push(`    ${addr}`));
+          } catch (e) {
+            reportLines.push(`    Error fetching details: ${e}`);
+          }
+        }
+        
+        if (result.missingFromProd > 0) {
+          reportLines.push(`  Missing from Production (${result.missingFromProd}):`);
+          try {
+            const localUrl = `http://localhost:${localPort}/${result.chain}/vaults/all?limit=1000`;
+            const prodUrl = `https://ydaemon.yearn.fi/${result.chain}/vaults/all?limit=1000`;
+            const [kongVaults, prodVaults] = await Promise.all([
+              fetchVaults(localUrl),
+              fetchVaults(prodUrl),
+            ]);
+            const prodSet = new Set(prodVaults);
+            const missingFromProd = kongVaults.filter(v => !prodSet.has(v));
+            missingFromProd.forEach(addr => reportLines.push(`    ${addr}`));
+          } catch (e) {
+            reportLines.push(`    Error fetching details: ${e}`);
+          }
+        }
+      }
+    }
+    
+    // Save report to file
+    const reportPath = "/home/murdertxxth/git/ydaemon/scripts/kong-integration/compare-vaults.txt";
+    await Bun.write(reportPath, reportLines.join("\n"));
+    console.log(`\n📄 Report saved: ${reportPath}`);
+    
+  } else {
+    // Single chain mode
+    const localUrl = `http://localhost:${localPort}/${chainId}/vaults/all?limit=1000`;
+    const prodUrl = `https://ydaemon.yearn.fi/${chainId}/vaults/all?limit=1000`;
+    
+    console.log("📥 Fetching vault lists...");
+    
+    const [kongVaults, prodVaults] = await Promise.all([
+      fetchVaults(localUrl),
+      fetchVaults(prodUrl),
+    ]);
+
+    console.log("📊 Vault counts:");
+    console.log(`   Kong (local):  ${kongVaults.length} vaults`);
+    console.log(`   Production:    ${prodVaults.length} vaults`);
+    console.log();
+
+    // Find differences
+    const kongSet = new Set(kongVaults);
+    const prodSet = new Set(prodVaults);
+    
+    const missingFromKong = prodVaults.filter(v => !kongSet.has(v));
+    const missingFromProd = kongVaults.filter(v => !prodSet.has(v));
+    const common = kongVaults.filter(v => prodSet.has(v));
+
+    console.log("📈 Differences:");
+    console.log(`   Common vaults:        ${common.length}`);
+    console.log(`   Missing from Kong:    ${missingFromKong.length}`);
+    console.log(`   Missing from Prod:    ${missingFromProd.length}`);
+    console.log();
+
+    if (missingFromKong.length > 0) {
+      console.log("🔻 Vaults in production but missing from Kong:");
+      missingFromKong.slice(0, 10).forEach(v => console.log(`   ${v}`));
+      if (missingFromKong.length > 10) console.log(`   ... and ${missingFromKong.length - 10} more`);
+      console.log();
+    }
+
+    if (missingFromProd.length > 0) {
+      console.log("🔺 Vaults in Kong but missing from production:");
+      missingFromProd.slice(0, 10).forEach(v => console.log(`   ${v}`));
+      if (missingFromProd.length > 10) console.log(`   ... and ${missingFromProd.length - 10} more`);
+      console.log();
+    }
+
+    // Test specific vault mentioned in issue (only for Ethereum)
+    if (chainId === "1") {
+      const testVault = "0x00CB87656196dD835b9E4d67018aE0477a1De8C1";
+      console.log(`🧪 Testing specific vault: ${testVault}`);
+      
+      const inKong = kongSet.has(testVault.toLowerCase());
+      const inProd = prodSet.has(testVault.toLowerCase());
+      
+      console.log(`   ${inKong ? "✅" : "❌"} ${inKong ? "Found" : "NOT found"} in Kong`);
+      console.log(`   ${inProd ? "✅" : "❌"} ${inProd ? "Found" : "NOT found"} in production`);
+
+      // Check directly in Kong GraphQL
+      console.log();
+      console.log("🔍 Checking Kong GraphQL directly for test vault...");
+      const inKongDirect = await checkKongDirectly(testVault);
+      console.log(`   ${inKongDirect ? "✅" : "❌"} ${inKongDirect ? "Found" : "NOT found"} in Kong GraphQL directly`);
+    }
+
+    console.log();
+    console.log("✅ Comparison complete!");
+    
+    // Save to files for further analysis
+    await Bun.write(`/tmp/kong_vaults_${chainId}.txt`, kongVaults.join("\n"));
+    await Bun.write(`/tmp/prod_vaults_${chainId}.txt`, prodVaults.join("\n"));
+    console.log(`📁 Files saved:`);
+    console.log(`   Kong vaults:     /tmp/kong_vaults_${chainId}.txt`);
+    console.log(`   Production vaults: /tmp/prod_vaults_${chainId}.txt`);
+  }
+}
+
+main().catch(console.error);


### PR DESCRIPTION
re https://github.com/yearn/ySHIP/issues/164

## Summary
Replace blockchain registry and contract querying with Kong GraphQL API as the single source of truth for vault and strategy discovery. This is part of the broader roadmap to replace yDaemon internals with Kong queries.

## Changes
- Add Kong GraphQL client with `yearn=true` filtering for vault and strategy discovery
- Replace `IndexNewVaults`/`IndexNewStrategies` with Kong-based implementations
- Implement fail-fast behavior when Kong unavailable (no fallback) to ensure data consistency
- Rename legacy blockchain-based discovery functions for clarity

## Validation
Two comparison scripts were created to validate Kong data against legacy blockchain-based discovery:

### Compare Vaults Results
Most vault differences were on Optimism due to a registry missing/omitted on the yDaemon side. All affected vaults were already marked as "legacy" in CMS - **no UI change**.

The cause of the remaining vault differences was unclear, but migrating to Kong will **add** these vaults to the UI:
- (Base) True Dollar Yield `0xb13CF163d916917d9cD6E836905cA5f12a1dEF4B`
- (Arbitrum) USDC-A `0x6faf8b7ffee3306efcfc2ba9fec912b4d49834c1`
- (Arbitrum) USDT-A `0xc0ba9bfED28aB46Da48d2B69316A3838698EF3f5`

### Compare Strategies Results
Most differences in available strategies result in no UI changes with one exception: yDaemon is missing several v2 router strategies to major v2 vaults. The result is the UI showing incorrect strategy composition for vaults like WETH. Kong has the routers. After integration with yDaemon, **the UI will now show these routers correctly** on v2 vaults.

V2 vaults that will now show routers correctly:
- WETH `0xa258C4606Ca8206D8aA700cE2143D7db854D168c`
- WBTC `0xA696a63cc78DfFa1a63E9E50587C197387FF6C7E`
- DAI `0xdA816459F1AB5631232FE5e97a05BBBb94970c95`
- USDC `0xa354F35829Ae975e850e23e9615b11Da1B3dC4DE`
- USDT `0x3B27F92C0e212C671EA351827EDF93DB27cc0c65`

In another case, Fantom v2 YFI `0x2C850cceD00ce2b14AA9D658b7Cad5dF659493Db` is currently missing a lender strategy that will now show: `0xdf262b43bea0acd0dd5832cf2422e0c9b2c539dc`.

## How to Test
1. Run this branch of yDaemon in dev. Start yDaemon and give it enough time to index
2. Run yearn.fi in dev, configured for your dev yDaemon API
3. Compare localhost yearn.fi with production yearn.fi

**Expected result:** The only differences should be the addition of previously missing data (vaults and router strategies listed above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)