### PR TITLE
Use singleflight request coalescing to deduplicate concurrent cache misses

### DIFF
--- a/cmd/cache.go
+++ b/cmd/cache.go
@@ -8,15 +8,23 @@ import (
 	"github.com/patrickmn/go-cache"
 	"github.com/yearn/ydaemon/common/logs"
 	"github.com/yearn/ydaemon/external/vaults"
+	"golang.org/x/sync/singleflight"
 )
 
 type GetSimplifiedVaults func(c *gin.Context) ([]vaults.TSimplifiedExternalVault, error)
 type GetLegacyExternalVaults func(c *gin.Context) []vaults.TExternalVault
 type GetCustomVaults func(c *gin.Context) []vaults.TRotkiVaults
 
+var simplifiedVaultsSingleflight singleflight.Group
+var legacyVaultsSingleflight singleflight.Group
+var customVaultsSingleflight singleflight.Group
+
 func CacheSimplifiedVaults(cachingStore *cache.Cache, expire time.Duration, handle GetSimplifiedVaults) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		if result, found := cachingStore.Get(c.Request.URL.String()); found && result != nil {
+		cacheKey := c.Request.URL.String()
+
+		// Check cache first
+		if result, found := cachingStore.Get(cacheKey); found && result != nil {
 			vaults, ok := result.([]vaults.TSimplifiedExternalVault)
 			if ok && len(vaults) > 0 {
 				c.JSON(http.StatusOK, vaults)
@@ -24,27 +32,42 @@ func CacheSimplifiedVaults(cachingStore *cache.Cache, expire time.Duration, hand
 			}
 		}
 
-		result, err := handle(c)
+		// Use singleflight to prevent thundering herd on cache miss
+		// Only one goroutine will execute the handler, others will wait for the result
+		result, err, shared := simplifiedVaultsSingleflight.Do(cacheKey, func() (interface{}, error) {
+			vaults, err := handle(c)
+			if err != nil {
+				return nil, err
+			}
+
+			// Cache the result
+			if len(vaults) > 0 {
+				cachingStore.Set(cacheKey, vaults, expire)
+				logs.Info(`Cache miss with`, len(vaults), `vaults`)
+			}
+
+			return vaults, nil
+		})
+
 		if err != nil {
 			logs.Error(`Error while getting simplified vaults`, err)
-			//Json was already sent
 			return
 		}
-		if len(result) > 0 {
-			if _, found := cachingStore.Get(c.Request.URL.String()); found {
-				logs.Info(`Cache hit with`, len(result), `vaults`)
-			} else {
-				cachingStore.Set(c.Request.URL.String(), result, expire)
-				logs.Info(`Cache miss with`, len(result), `vaults`)
-			}
+
+		if shared {
+			logs.Info(`Singleflight shared result with`, len(result.([]vaults.TSimplifiedExternalVault)), `vaults`)
 		}
+
 		c.JSON(http.StatusOK, result)
 	}
 }
 
 func CacheLegacyVaults(cachingStore *cache.Cache, expire time.Duration, handle GetLegacyExternalVaults) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		if result, found := cachingStore.Get(c.Request.URL.String()); found && result != nil {
+		cacheKey := c.Request.URL.String()
+
+		// Check cache first
+		if result, found := cachingStore.Get(cacheKey); found && result != nil {
 			vaults, ok := result.([]vaults.TExternalVault)
 			if ok && len(vaults) > 0 {
 				c.JSON(http.StatusOK, vaults)
@@ -52,15 +75,38 @@ func CacheLegacyVaults(cachingStore *cache.Cache, expire time.Duration, handle G
 			}
 		}
 
-		result := handle(c)
-		cachingStore.Set(c.Request.URL.String(), result, expire)
+		// Use singleflight to prevent thundering herd on cache miss
+		result, err, shared := legacyVaultsSingleflight.Do(cacheKey, func() (interface{}, error) {
+			vaults := handle(c)
+
+			// Cache the result
+			if len(vaults) > 0 {
+				cachingStore.Set(cacheKey, vaults, expire)
+				logs.Info(`Cache miss with`, len(vaults), `legacy vaults`)
+			}
+
+			return vaults, nil
+		})
+
+		if err != nil {
+			logs.Error(`Error while getting legacy vaults`, err)
+			return
+		}
+
+		if shared {
+			logs.Info(`Singleflight shared result with`, len(result.([]vaults.TExternalVault)), `legacy vaults`)
+		}
+
 		c.JSON(http.StatusOK, result)
 	}
 }
 
 func CacheCustomVaults(cachingStore *cache.Cache, expire time.Duration, handle GetCustomVaults) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		if result, found := cachingStore.Get(c.Request.URL.String()); found && result != nil {
+		cacheKey := c.Request.URL.String()
+
+		// Check cache first
+		if result, found := cachingStore.Get(cacheKey); found && result != nil {
 			vaults, ok := result.([]vaults.TRotkiVaults)
 			if ok && len(vaults) > 0 {
 				c.JSON(http.StatusOK, vaults)
@@ -68,8 +114,28 @@ func CacheCustomVaults(cachingStore *cache.Cache, expire time.Duration, handle G
 			}
 		}
 
-		result := handle(c)
-		cachingStore.Set(c.Request.URL.String(), result, expire)
+		// Use singleflight to prevent thundering herd on cache miss
+		result, err, shared := customVaultsSingleflight.Do(cacheKey, func() (interface{}, error) {
+			vaults := handle(c)
+
+			// Cache the result
+			if len(vaults) > 0 {
+				cachingStore.Set(cacheKey, vaults, expire)
+				logs.Info(`Cache miss with`, len(vaults), `custom vaults`)
+			}
+
+			return vaults, nil
+		})
+
+		if err != nil {
+			logs.Error(`Error while getting custom vaults`, err)
+			return
+		}
+
+		if shared {
+			logs.Info(`Singleflight shared result with`, len(result.([]vaults.TRotkiVaults)), `custom vaults`)
+		}
+
 		c.JSON(http.StatusOK, result)
 	}
 }


### PR DESCRIPTION
Use singleflight request coalescing to deduplicate concurrent cache misses. Prevents redundant vault processing when multiple requests miss cache concurrently.

## Problem
Over the last couple of weeks we've observed many CPU exhaustion events causing ydaemon to become unresponsive until restarted.

We have seen these CPU runaway events in the past. And we have seen extended periods when runaways seemed to "cluster" for a day or two before calming down again. But recent CPU events have been more frequent.

## Root Cause

The root cause addressed here is a race condition on the api's vault endpoint cache.

When the vaults HTTP response cache expires, concurrent requests each independently rebuild the vault cache. This causes sudden CPU spikes because:

- Cache check happens before processing (line 27 cache.go)
- Cache set happens after processing (line 37 cache.go)
- No deduplication between check and set
- Multiple requests see expired cache and each starts its own expensive vault processing

This bug was introduced here, https://github.com/yearn/ydaemon/commit/31fc81f30c470875afc818e7ffb54d087bf8beda, unironically titled "fix: cache?".

The original cache logic had a simple cache-miss-then-process flow. But commit 31fc81f30, from November 2024, changed the structure by adding early returns in the cache-hit path without preventing concurrent cache misses from all calling handle(c) concurrently.

## Solution

Implemented `golang.org/x/sync/singleflight` pattern:
- Only ONE goroutine processes vaults on cache miss
- All other concurrent requests WAIT for that result
- Dramatically reduces redundant processing (95%+ reduction in CPU usage during cache misses)

## Testing

Temporarily added `/test/thundering-herd` endpoint in dev to verify:
- Flushes cache to guarantee misses
- Spawns staggered concurrent requests
- CPU usage remains controlled vs spiking to 100%

50 concurrent requests with 1s stagger before singleflight fix
<img width="1504" height="293" alt="Screenshot 2025-10-08 at 11 48 03 PM" src="https://github.com/user-attachments/assets/7dcef533-4704-450c-bb0e-0563694158c0" />

50 concurrent requests with 1s stagger after singleflight fix
<img width="1497" height="277" alt="Screenshot 2025-10-08 at 11 13 17 PM" src="https://github.com/user-attachments/assets/3fe0d2c9-9607-4bd9-b632-788404ad8ab8" />

### thundering-herd endpoint

```go

// Test endpoint to simulate thundering herd condition
router.GET(`/test/thundering-herd`, func(ctx *gin.Context) {
        concurrency := 20 // Number of concurrent requests to simulate
        stagger := 250 * time.Millisecond
        if c := ctx.Query("concurrency"); c != "" {
                if n, err := strconv.Atoi(c); err == nil && n > 0 && n <= 100 {
                        concurrency = n
                }
        }
        if s := ctx.Query("stagger"); s != "" {
                if n, err := strconv.Atoi(s); err == nil && n > 0 && n <= 1000 {
                        stagger = time.Duration(n) * time.Millisecond
                }
        }

        // Flush the cache to guarantee cache misses
        cachingStore.Flush()

        // Small delay to ensure cache is cleared
        time.Sleep(100 * time.Millisecond)

        // Make concurrent HTTP requests to the vaults endpoint
        results := make(chan string, concurrency)
        startTime := time.Now()

        for i := 0; i < concurrency; i++ {
                go func(id int) {
                        reqStart := time.Now()

                        // Make actual HTTP request to trigger cache middleware
                        resp, err := http.Get("http://localhost:8080/vaults/all")
                        reqDuration := time.Since(reqStart)

                        status := "OK"
                        if err != nil {
                                status = "ERROR: " + err.Error()
                        } else {
                                resp.Body.Close()
                                status = fmt.Sprintf("HTTP %d", resp.StatusCode)
                        }
                        results <- fmt.Sprintf("Request %d: %s (%.2fs)", id, status, reqDuration.Seconds())

                        time.Sleep(stagger * time.Millisecond)
                }(i)
        }

        // Collect results
        var responses []string
        for i := 0; i < concurrency; i++ {
                responses = append(responses, <-results)
        }
        totalDuration := time.Since(startTime)

        ctx.JSON(http.StatusOK, gin.H{
                "test":        "thundering-herd",
                "concurrency": concurrency,
                "duration":    totalDuration.Seconds(),
                "results":     responses,
                "warning":     "Check CPU usage and logs for 'Cache miss' messages",
        })
})

```
