### PR TITLE
chore: update workflow timeout to 13min

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           ./yDaemon | tee out.log &
           pid=$!
-          timeout=600
+          timeout 780
           while ! grep -q "\[ OK \] \[1 - ComputeChainAPY ✅\]" <(tail -n 100 out.log); do
             sleep 5
             timeout=$((timeout - 5))


### PR DESCRIPTION
The deploy step is timing out before the snapshot completes. This increases the timeout length for the workflow responsible by 3 minutes to assure the snapshot has time to complete.