### PR TITLE
Fix vault fees returning zero after Kong GraphQL migration

### DIFF
--- a/external/vaults/models.go
+++ b/external/vaults/models.go
@@ -359,17 +359,9 @@ func ApplyKongData(externalVault *TExternalVault, vault models.TVault) {
 		return
 	}
 
-	// Apply kong fees with priority: hook > snapshot > vault model
-	managementFee := kongData.Snapshot.ManagementFee.Value
-	performanceFee := kongData.Snapshot.PerformanceFee.Value
-
-	// Override with hook fees if they exist (hook takes precedence)
-	if kongData.Hook.Fees.ManagementFee != 0 {
-		managementFee = kongData.Hook.Fees.ManagementFee
-	}
-	if kongData.Hook.Fees.PerformanceFee != 0 {
-		performanceFee = kongData.Hook.Fees.PerformanceFee
-	}
+	// Apply Kong fees (already in basis points from Kong API)
+	managementFee := kongData.ManagementFee
+	performanceFee := kongData.PerformanceFee
 
 	// Convert from basis points to percentage and apply to APR fees
 	externalVault.APR.Fees.Management = bigNumber.NewFloat(float64(managementFee) / 10000.0)

--- a/internal/indexer/indexer.kong.go
+++ b/internal/indexer/indexer.kong.go
@@ -41,9 +41,11 @@ func IndexNewVaults(chainID uint64) map[common.Address]models.TVaultsFromRegistr
 		vaultsFromKong[vaultAddr] = vault
 		storage.StoreNewVaultToRegistry(chainID, vault)
 
-		// Store Kong APY data from GraphQL API (single source of truth for APY calculations)
+		// Store Kong APY and fee data from GraphQL API (single source of truth)
 		kongSchema := models.TKongVaultSchema{
-			APY: data.APY,
+			APY:            data.APY,
+			ManagementFee:  data.Vault.GetManagementFee(),
+			PerformanceFee: data.Vault.GetPerformanceFee(),
 		}
 		storage.StoreKongVaultData(chainID, vaultAddr, kongSchema)
 	}

--- a/internal/models/vaults.go
+++ b/internal/models/vaults.go
@@ -291,15 +291,7 @@ type KongAPY struct {
 }
 
 type TKongVaultSchema struct {
-	Hook struct {
-		Fees struct {
-			ManagementFee  uint64 `json:"managementFee"`
-			PerformanceFee uint64 `json:"performanceFee"`
-		} `json:"fees"`
-	} `json:"hook"`
-	Snapshot struct {
-		ManagementFee  CoercibleUint64 `json:"managementFee"`
-		PerformanceFee CoercibleUint64 `json:"performanceFee"`
-	} `json:"snapshot"`
-	APY KongAPY `json:"apy"`
+	APY            KongAPY `json:"apy"`
+	ManagementFee  uint64  `json:"managementFee"`  // Basis points from Kong (direct field takes priority)
+	PerformanceFee uint64  `json:"performanceFee"` // Basis points from Kong (direct field takes priority)
 }


### PR DESCRIPTION
Commit 2e37cec8 migrated from Kong's PostgreSQL database to Kong's GraphQL API for APY data, but removed the RefreshKongData scheduler that was fetching fee information from the database. The new GraphQL queries didn't include fee fields, leaving all vault fees at zero.

Changes:
- Add managementFee, performanceFee, and fees fields to Kong GraphQL queries
- Update KongVault struct with fee fields (BigInt strings + fallback object)
- Add GetManagementFee() and GetPerformanceFee() methods with priority logic
- Simplify TKongVaultSchema to match Kong GraphQL API structure
- Update indexer to populate fee data during vault indexing
- Simplify ApplyKongData to read fees directly from Kong data

🤖 Generated with [Claude Code](https://claude.com/claude-code)