### PR TITLE
feat: add ishidden to vault endpoint

### DIFF
--- a/external/vaults/models.go
+++ b/external/vaults/models.go
@@ -133,6 +133,7 @@ type TExternalVaultInfo struct {
 	RiskLevel        int8     `json:"riskLevel"`           // The risk level of the vault. The value is a calculated from the sum of all risk score from the object for Single Strategy Vaults. Multi-Strategy Vault, highest `riskLevel` of all strategies is set. 1 is the most secure and 5 is the least secure.
 	UINotice         string   `json:"uiNotice,omitempty"`  // The notice to display in the UI
 	IsRetired        bool     `json:"isRetired"`
+	IsHidden         bool     `json:"isHidden"`
 	IsBoosted        bool     `json:"isBoosted"`
 	IsHighlighted    bool     `json:"isHighlighted"`
 	RiskScore        [11]int8 `json:"riskScore"`                  // All risk scores of the Single Strategy Vault. Multi-Strategy Vault won't have this object because its risk score is combination of multiple vaults. For risk value use `riskLevel`. (empty for Multi-Strategy Vault). Array of 11 integers: [review, testing, complexity, riskExposure, protocolIntegration, centralizationRisk, externalProtocolAudit, externalProtocolCentralisation, externalProtocolTvl, externalProtocolLongevity, externalProtocolType]
@@ -499,6 +500,7 @@ func CreateExternalVault(vault models.TVault) (TExternalVault, error) {
 		Info: TExternalVaultInfo{
 			SourceURL: vault.Metadata.SourceURI,
 			RiskLevel: vault.Metadata.RiskLevel,
+			IsHidden:  vault.Metadata.IsHidden,
 			RiskScore: [11]int8{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 		},
 	}

--- a/external/vaults/prepare.vaultObject.go
+++ b/external/vaults/prepare.vaultObject.go
@@ -185,6 +185,7 @@ func toSimplifiedVersion(
 	// Create a copy of the info struct to avoid mutating the original
 	info := vault.Info
 	info.IsRetired = vault.Details.IsRetired
+	info.IsHidden = vault.Details.IsHidden
 	info.IsBoosted = vault.Details.IsBoosted
 	info.IsHighlighted = vault.Details.IsHighlighted
 


### PR DESCRIPTION
This adds an `info.isHidden` flag to the typical vault endpoint at ydaemon.yearn.fi/{chainId}/vaults{address}, to be consumed by the yearn.fi and other websites