### PR TITLE
Only use oracle.getStrategyApr for V3 estimated APR calculation

### DIFF
--- a/processes/apr/forward.v3.go
+++ b/processes/apr/forward.v3.go
@@ -39,117 +39,31 @@ func computeVaultV3ForwardAPY(
 	}
 
 	/**********************************************************************************************
-	** If the vault is a single strategy vault, we can use the oracle directly to get the APR of
-	** the vault as expected APR
+	** Use the oracle to get the APR of the vault. The oracle automatically handles:
+	** - Single strategy vaults: Returns strategy APR
+	** - Multi-strategy vaults: Returns weighted average with performance fees applied
 	**********************************************************************************************/
-	var hasError error
 	expected, err := oracle.GetStrategyApr(nil, vault.Address, big.NewInt(0))
-	if err == nil {
-		oracleAPR = helpers.ToNormalizedAmount(bigNumber.SetInt(expected), 18)
-	} else {
-		hasError = err
+	if err != nil {
+		logs.Error(`GetStrategyApr failed for vault ` + vault.Address.Hex() + `: ` + err.Error())
+		return TForwardAPY{}
 	}
-
-	if hasError != nil || oracleAPR.IsZero() {
-		expected, err := oracle.GetCurrentApr(nil, vault.Address)
-		if err == nil {
-			oracleAPR = helpers.ToNormalizedAmount(bigNumber.SetInt(expected), 18)
-		}
-	}
+	oracleAPR = helpers.ToNormalizedAmount(bigNumber.SetInt(expected), 18)
 
 	/**********************************************************************************************
-	** Otherwise we can do the classic calculation of the net APR by summing the APR of each
-	** strategy weighted by the debt ratio of each strategy.
-	**********************************************************************************************/
-	debtRatioAPR := bigNumber.NewFloat(0)
-	if vault.Kind == models.VaultKindMultiple {
-		/******************************************************************************************
-		** Edge case request by Mil0x: If the vault has no total assets (aka no deposits), we want
-		** to display the APR of the first strategy in the queue. This is because the APR of the
-		** vault is 0% and we want to show the APR of the strategy to give an idea of the potential
-		** return.
-		******************************************************************************************/
-		if vault.LastTotalAssets == nil || vault.LastTotalAssets.IsZero() {
-			if len(allStrategiesForVault) > 0 {
-				for _, strategy := range allStrategiesForVault {
-					expected, err := oracle.GetStrategyApr(nil, strategy.Address, big.NewInt(0))
-					if err != nil {
-						logs.Error(`GetStrategyApr ` + err.Error() + " for strategy " + strategy.Address.Hex())
-						continue
-					}
-					humanizedAPR := helpers.ToNormalizedAmount(bigNumber.SetInt(expected), 18)
-
-					// Scaling based on the performance fee
-					// Retrieve the ratio we should use to take into account the performance fee. If the performance fee is 10%, the ratio is 0.9
-					// 10_000 is the precision. Ex: 1 - (1000 / 10_000)
-					performanceFeeFloat := bigNumber.NewFloat(0).SetInt(strategy.LastPerformanceFee)
-					performanceFee := bigNumber.NewFloat(0).Div(performanceFeeFloat, bigNumber.NewFloat(10_000))
-					performanceFee = bigNumber.NewFloat(0).Sub(bigNumber.NewFloat(1), performanceFee)
-					scaledStrategyAPR := bigNumber.NewFloat(0).Mul(humanizedAPR, performanceFee)
-
-					debtRatioAPR = bigNumber.NewFloat(0).Add(debtRatioAPR, scaledStrategyAPR)
-					debtRatioAPR = bigNumber.NewFloat(0).Mul(debtRatioAPR, bigNumber.NewFloat(0.9))
-					// We only want the first strategy
-					break
-				}
-			}
-		} else {
-			for _, strategy := range allStrategiesForVault {
-				if strategy.LastDebtRatio == nil || strategy.LastDebtRatio.IsZero() {
-					continue
-				}
-
-				expected, err := oracle.GetStrategyApr(nil, strategy.Address, big.NewInt(0))
-				if err != nil {
-					logs.Error(`GetStrategyApr ` + err.Error() + " for strategy " + strategy.Address.Hex())
-					continue
-				}
-				humanizedAPR := helpers.ToNormalizedAmount(bigNumber.SetInt(expected), 18)
-				debtRatio := helpers.ToNormalizedAmount(strategy.LastDebtRatio, 4)
-				scaledStrategyAPR := bigNumber.NewFloat(0).Mul(humanizedAPR, debtRatio)
-
-				// Scaling based on the performance fee
-				// Retrieve the ratio we should use to take into account the performance fee. If the performance fee is 10%, the ratio is 0.9
-				// 10_000 is the precision. Ex: 1 - (1000 / 10_000)
-				performanceFeeFloat := bigNumber.NewFloat(0).SetInt(strategy.LastPerformanceFee)
-				performanceFee := bigNumber.NewFloat(0).Div(performanceFeeFloat, bigNumber.NewFloat(10_000))
-				performanceFee = bigNumber.NewFloat(0).Sub(bigNumber.NewFloat(1), performanceFee)
-				scaledStrategyAPR = bigNumber.NewFloat(0).Mul(scaledStrategyAPR, performanceFee)
-
-				debtRatioAPR = bigNumber.NewFloat(0).Add(debtRatioAPR, scaledStrategyAPR)
-			}
-
-			/******************************************************************************************
-			** Adjustement request by Schlag: Reduce the APR by 10% to account for the fees/slippage
-			** and other factors
-			******************************************************************************************/
-			debtRatioAPR = bigNumber.NewFloat(0).Mul(debtRatioAPR, bigNumber.NewFloat(0.9))
-		}
-	}
-
-	/**********************************************************************************************
-	** Define which APR we want to use as "Net APR".
+	** Use the oracle APR as the primary APR (no manual calculation needed)
 	**********************************************************************************************/
 	primaryAPR := oracleAPR
-	if vault.Metadata.ShouldUseV2APR {
-		primaryAPR = debtRatioAPR
-	}
 
 	primaryAPRFloat64, _ := primaryAPR.Float64()
 	primaryAPY := bigNumber.NewFloat(0).SetFloat64(convertFloatAPRToAPY(primaryAPRFloat64, 52))
-
-	oracleAPRFloat64, _ := oracleAPR.Float64()
-	oracleAPY := bigNumber.NewFloat(0).SetFloat64(convertFloatAPRToAPY(oracleAPRFloat64, 52))
-
-	debtRatioAPRFloat64, _ := debtRatioAPR.Float64()
-	debtRatioAPY := bigNumber.NewFloat(0).SetFloat64(convertFloatAPRToAPY(debtRatioAPRFloat64, 52))
 
 	return TForwardAPY{
 		Type:   `v3:onchainOracle`,
 		NetAPY: primaryAPY,
 		Composite: TCompositeData{
-			V3OracleCurrentAPR:    oracleAPY,
-			V3OracleStratRatioAPR: debtRatioAPY,
+			V3OracleCurrentAPR:    primaryAPY,
+			V3OracleStratRatioAPR: bigNumber.NewFloat(0),
 		},
 	}
 }


### PR DESCRIPTION
This change simplifies the forward APR calculation by using only the oracle's getStrategyApr method, which already performs weighted averaging with performance fees applied on-chain. Removes all manual calculation logic.

Changes:
- Removed ShouldUseV2APR logic that allowed switching between calculation methods
- Removed 10% fees\slippage adjustment (was artificially reducing APR values)
- Removed zero-assets edge case that returned first strategy APR (deferred to frontend)
- Set V3OracleStratRatioAPR to 0 in API response (manual calculation no longer used)

The 49 vaults previously using ShouldUseV2APR will now show oracle-calculated APR values, which are ~10% higher and more accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Tested in dev by comparing sidebyside with yearn.fi,

<img width="1491" height="933" alt="Screenshot 2025-11-12 at 2 38 26 AM" src="https://github.com/user-attachments/assets/24627085-0d81-499d-a06b-1281b8ab8416" />

Expected: allocator vaults now show 10% higher estimated apr
