### PR TITLE
fix: update risk score fetching to use manifest files

### DIFF
--- a/internal/main.go
+++ b/internal/main.go
@@ -150,12 +150,9 @@ func InitializeV2(chainID uint64, wg *sync.WaitGroup) {
 				_, _, vaultMap, tokenMap = initVaults(chainID)
 				logs.Success(fmt.Sprintf("🧩 [SNAPSHOT] initVaults done chain=%d vaults=%d tokens=%d", chainID, len(vaultMap), len(tokenMap)))
 
-				tRiskAvail := time.Now()
+				tRisk := time.Now()
 				risks.RetrieveAvailableRiskScores(chainID)
-				logs.Info(fmt.Sprintf("🧩 [SNAPSHOT] risks availability chain=%d took=%s", chainID, time.Since(tRiskAvail)))
-				tRiskAll := time.Now()
-				risks.RetrieveAllRiskScores(chainID, vaultMap)
-				logs.Info(fmt.Sprintf("🧩 [SNAPSHOT] risks full chain=%d took=%s", chainID, time.Since(tRiskAll)))
+				logs.Info(fmt.Sprintf("🧩 [SNAPSHOT] risks loaded chain=%d took=%s", chainID, time.Since(tRisk)))
 
 				tStake := time.Now()
 				initStakingPools(chainID)


### PR DESCRIPTION
The risk-score repository has migrated from individual vault files (vaults/{chainID}/{address}.json) to consolidated manifest files (vaults/{chainID}.json). This caused RetrieveAvailableRiskScores to find zero vaults since it was looking for a directory structure that no longer exists.

Changes:
- Replace individual file scanning with manifest file detection
- Fetch entire manifest in a single request instead of per-vault
- Populate both availableRiskScores and allRisksScores cache from manifest

Benefits:
- Reduces network requests from N (one per vault) to 1 (manifest file)
- Pre-populates cache, eliminating redundant fetches in RetrieveAllRiskScores
- Compatible with new risk-score repository structure

Review: Vaults to check when running fix:

missing here: https://ydaemon.yearn.fi/747474/vaults/0x78EC25FBa1bAf6b7dc097Ebb8115A390A2a4Ee12
exists here: https://github.com/yearn/risk-score/blob/e1e290a2348bfbb7d6f4cf2214f0b2a7505e13cc/vaults/747474.json#L121

missing here: https://ydaemon.yearn.fi/8453/vaults/0xb13CF163d916917d9cD6E836905cA5f12a1dEF4B
exists here: https://github.com/yearn/risk-score/blob/e1e290a2348bfbb7d6f4cf2214f0b2a7505e13cc/vaults/8453.json#L291

missing here: https://ydaemon.yearn.fi/8453/vaults/0x25f32eC89ce7732A4E9f8F3340a09259F823b7d3
exists here: https://github.com/yearn/risk-score/blob/e1e290a2348bfbb7d6f4cf2214f0b2a7505e13cc/vaults/8453.json#L70

missing here: https://ydaemon.yearn.fi/8453/vaults/0xc3BD0A2193c8F027B82ddE3611D18589ef3f62a9
exists here: https://github.com/yearn/risk-score/blob/e1e290a2348bfbb7d6f4cf2214f0b2a7505e13cc/vaults/8453.json#L359

missing here: https://ydaemon.yearn.fi/1/vaults/0x89E93172AEF8261Db8437b90c3dCb61545a05317
exists here: https://github.com/yearn/risk-score/blob/e1e290a2348bfbb7d6f4cf2214f0b2a7505e13cc/vaults/1.json#L988