### PR TITLE
Refactor risk score fetch to eliminate redundancies

### DIFF
--- a/internal/main.go
+++ b/internal/main.go
@@ -150,12 +150,9 @@ func InitializeV2(chainID uint64, wg *sync.WaitGroup) {
 				_, _, vaultMap, tokenMap = initVaults(chainID)
 				logs.Success(fmt.Sprintf("🧩 [SNAPSHOT] initVaults done chain=%d vaults=%d tokens=%d", chainID, len(vaultMap), len(tokenMap)))
 
-				tRiskAvail := time.Now()
+				tRisk := time.Now()
 				risks.RetrieveAvailableRiskScores(chainID)
-				logs.Info(fmt.Sprintf("🧩 [SNAPSHOT] risks availability chain=%d took=%s", chainID, time.Since(tRiskAvail)))
-				tRiskAll := time.Now()
-				risks.RetrieveAllRiskScores(chainID, vaultMap)
-				logs.Info(fmt.Sprintf("🧩 [SNAPSHOT] risks full chain=%d took=%s", chainID, time.Since(tRiskAll)))
+				logs.Info(fmt.Sprintf("🧩 [SNAPSHOT] risks loaded chain=%d took=%s", chainID, time.Since(tRisk)))
 
 				tStake := time.Now()
 				initStakingPools(chainID)


### PR DESCRIPTION
Removed fetchVaultsRiskScore and RetrieveAllRiskScores functions that were making N individual vault requests after the manifest was already fetched. Also eliminated unnecessary GitHub API tree lookup by fetching manifest directly from CDN.

This significantly simplifies the code and reduces HTTP requests from N+2 to 1 per chain, using only the CDN manifest.

### Root cause

This better addresses the root cause of https://github.com/yearn/ydaemon/pull/552. The root cause was introduced in https://github.com/yearn/ydaemon/commit/bb9902c7a90df497891519d78c249cfa7633a7a3 which should have completely removed the original risk caching pipeline that relied on github api calls. that pipeline was over complicated and calling the github api may have rate limit issues. we only need the cdn directly. and now that we can access risk in manifests by chain, we can simplify even more.

### How I tested
i ran ydaemon on localhost and used using curl and jq to compare against production.

missing vs fixed

```
curl -s https://ydaemon.yearn.fi/747474/vaults/0x78EC25FBa1bAf6b7dc097Ebb8115A390A2a4Ee12 | jq '.info'
curl -s http://localhost:3001/747474/vaults/0x78EC25FBa1bAf6b7dc097Ebb8115A390A2a4Ee12 | jq '.info'
```

```
curl -s https://ydaemon.yearn.fi/8453/vaults/0xb13CF163d916917d9cD6E836905cA5f12a1dEF4B | jq '.info'
curl -s http://localhost:3001/8453/vaults/0xb13CF163d916917d9cD6E836905cA5f12a1dEF4B | jq '.info'
```

```
curl -s https://ydaemon.yearn.fi/8453/vaults/0x25f32eC89ce7732A4E9f8F3340a09259F823b7d3 | jq '.info'
curl -s http://localhost:3001/8453/vaults/0x25f32eC89ce7732A4E9f8F3340a09259F823b7d3 | jq '.info'
```

```
curl -s https://ydaemon.yearn.fi/8453/vaults/0xc3BD0A2193c8F027B82ddE3611D18589ef3f62a9 | jq '.info'
curl -s http://localhost:3001/8453/vaults/0xc3BD0A2193c8F027B82ddE3611D18589ef3f62a9 | jq '.info'
```

```
curl -s https://ydaemon.yearn.fi/1/vaults/0x89E93172AEF8261Db8437b90c3dCb61545a05317 | jq '.info'
curl -s http://localhost:3001/1/vaults/0x89E93172AEF8261Db8437b90c3dCb61545a05317 | jq '.info'
```
