### PR TITLE
Remove stale strategies from cache after Kong sync

### DIFF
--- a/internal/storage/elem.strategies.go
+++ b/internal/storage/elem.strategies.go
@@ -427,6 +427,17 @@ func ListStrategiesForVault(chainID uint64, vaultAddress common.Address) (
 }
 
 /**************************************************************************************************
+** DeleteStrategy removes a single strategy from the cache by its key.
+**
+** @param chainID The blockchain network ID
+** @param strategyKey The strategy key (strategyAddress_vaultAddress)
+**************************************************************************************************/
+func DeleteStrategy(chainID uint64, strategyKey string) {
+	syncMap := safeSyncMap(_strategiesSyncMap, chainID)
+	syncMap.Delete(strategyKey)
+}
+
+/**************************************************************************************************
 ** GetManualStrategiesForVault returns a list of manual strategies for a specific vault.
 ** Manual strategies are human-curated strategies that should be added to a vault's active strategies
 ** list in addition to those discovered automatically from the vault's default queue.


### PR DESCRIPTION
Strategies that were removed from vaults persisted in the cache with stale debt data, causing them to appear in API responses. This fix compares the cache against Kong's current strategy list after each sync and removes strategies that Kong no longer returns.

The cleanup happens after fresh strategies are fetched and stored, preventing any race condition where the API would return empty strategy lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Problem
Yearn.fi is showing outdated\stale strategies, notably usds-1 https://yearn.fi/v3/1/0x182863131F9a4630fF9E27830d945B1413e347E8

### Cause
Invalid strategies were not being removed after syncing with Kong. The solution is to remove strategies from ydaemon's cache when they no longer appear in Kong.

### How I tested
Tested in dev by comparing sidebyside with yearn.fi,
<img width="1810" height="941" alt="image" src="https://github.com/user-attachments/assets/caa4dd82-905d-4506-8614-eba55678a9ec" />
