### PR TITLE
Update risk.yearn.fi to curation.yearn.fi

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ GRAPH_API_URI=
 SENTRY_DSN=
 SENTRY_SAMPLE_RATE=
 LOG_LEVEL=          # DEBUG, INFO, WARNING, SUCCESS, ERROR
-RISK_CDN_URL=       # Risk score CDN URL (defaults to https://risk.yearn.fi/cdn/)
+RISK_CDN_URL=       # Risk score CDN URL (defaults to https://curation.yearn.fi/cdn/)
 ```
 
 ## Architecture Overview

--- a/common/env/constants.go
+++ b/common/env/constants.go
@@ -87,7 +87,7 @@ var CMS_ROOT_URL = ``
 ** The risk scores are stored as JSON files organized by chain ID and vault address.
 ** Default value points to the production CDN, but can be overridden via RISK_CDN_URL env variable.
 **************************************************************************************************/
-var RISK_CDN_URL = `https://risk.yearn.fi/cdn/`
+var RISK_CDN_URL = `https://curation.yearn.fi/cdn/`
 
 /**************************************************************************************************
 ** KONG_API_URL contains the GraphQL endpoint for Kong, the single source of truth for vault


### PR DESCRIPTION
## Summary
- Updates the default `RISK_CDN_URL` in `common/env/constants.go` from `risk.yearn.fi` to `curation.yearn.fi`
- Updates the corresponding env var documentation in `CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)